### PR TITLE
drafted changes to sombrero wrapper

### DIFF
--- a/apps/sombrero/src/spack.yaml
+++ b/apps/sombrero/src/spack.yaml
@@ -1,0 +1,4 @@
+spack:
+  specs:
+  - sombrero@2021-07-31
+  view: true


### PR DESCRIPTION
Some things to discuss:
1. what needs to be inside `SombreroBenchmark.__init__` and what does not?
2. sombrero is not able to make use of multithreading at the moment
   (it is not even compiled with `-fopenmp`), so `OMP_NUM_THREADS` has no effect
   (last time I tried activating openMP it made it slower than the MPI-only option)
3. I set the reference flops to 0 in the base class,
   mimicking what was done for the castep benchmark.
4. I added benchmarks for the strong scaling on the medium lattice 
   and the weak scaling on the medium lattice - this choice was pretty arbitrary.
   We need to discuss how many cases we want to run.
   Also, we use
   ```
   @rfm.parameterized_test(*scaling_config())
   ```
   but `scaling_config()` is shared between all the benchmarks.
   In principle there can be some cases we don't want to run
   with Sombrero in all the sizes (small, medium, large and very large)
   compared to other benchmarks - for that we might create 
   a `sombrero_filter_scaling_config(problem_size)` function 
   that filters out the unrealistic cases?
   Poking @edbennett for an educated opinion.