### PR TITLE
Add a base test class and new logging format

### DIFF
--- a/modules/base_test.py
+++ b/modules/base_test.py
@@ -1,0 +1,69 @@
+"""
+Base class definitions to enable consistent logging. Requires ReFrame v. 3.11.x
+"""
+import math
+import reframe as rfm
+from reframe.core.decorators import run_after
+
+
+class DiRACTest(rfm.RegressionTest):
+
+    num_total_cores = variable(int, loggable=True)
+    num_omp_threads = variable(int, loggable=True)
+    num_mpi_tasks = variable(int, loggable=True)
+    num_mpi_tasks_per_node = variable(int, loggable=True)
+    num_nodes = variable(int, loggable=True)
+
+    @run_after('setup')
+    def set_attributes_after_setup(self):
+        """Set the required MPI and OMP ranks/tasks/threads"""
+
+        self.num_mpi_tasks = self.num_tasks = max(self.num_total_cores//self.num_omp_threads, 1)
+
+        try:
+            cpus_per_node = self._current_partition.processor.num_cpus
+            if cpus_per_node is None:
+                raise AttributeError('Cannot determine the number of cores PP')
+
+            self.num_nodes = math.ceil(self.num_mpi_tasks / cpus_per_node)
+
+        except AttributeError:
+            print('WARNING: Failed to determine the number of nodes required '
+                  'defaulting to 1')
+            self.num_nodes = 1
+
+        self.num_mpi_tasks_per_node = math.ceil(self.num_mpi_tasks / self.num_nodes)
+        self.num_tasks_per_node = self.num_mpi_tasks_per_node
+
+        if self.num_total_cores // self.num_omp_threads == 0:
+            print('WARNING: Had fewer total number of cores than the default '
+                  f'number of OMP threads, using {self.num_total_cores} OMP '
+                  f'threads')
+            self.num_omp_threads = self.num_total_cores
+
+        self.num_cpus_per_task = self.num_omp_threads
+        self.variables = {
+            'OMP_NUM_THREADS': f'{self.num_cpus_per_task}',
+        }
+
+        self.extra_resources = {
+            'mpi': {'num_slots': self.num_mpi_tasks * self.num_cpus_per_task}
+        }
+
+
+"""
+# The following is a possible sample of a strong scaling benchmark 
+# ----------------------------------------------------------------------------- 
+
+@rfm.simple_test
+class StrongScalingBenchmark(GROMACSBenchmark):
+
+    variant = parameter([4 * i for i in range(1, 5)])
+    num_omp_threads = 4
+
+    @run_before('setup')
+    def set_total_num_cores(self):
+        # A ReFrame parameter cannot also be a variable, thus assign
+        # them to be equal at the start of the setup
+        self.num_total_cores = self.variant
+"""

--- a/modules/base_test.py
+++ b/modules/base_test.py
@@ -21,11 +21,11 @@ class DiRACTest(rfm.RegressionTest):
         self.num_mpi_tasks = self.num_tasks = max(self.num_total_cores//self.num_omp_threads, 1)
 
         try:
-            cpus_per_node = self._current_partition.processor.num_cpus
-            if cpus_per_node is None:
+            num_cores_per_node = self._current_partition.processor.num_cpus
+            if num_cores_per_node is None:
                 raise AttributeError('Cannot determine the number of cores PP')
 
-            self.num_nodes = math.ceil(self.num_mpi_tasks / cpus_per_node)
+            self.num_nodes = math.ceil(self.num_total_cores / num_cores_per_node)
 
         except AttributeError:
             print('WARNING: Failed to determine the number of nodes required '
@@ -36,7 +36,7 @@ class DiRACTest(rfm.RegressionTest):
         self.num_tasks_per_node = self.num_mpi_tasks_per_node
 
         if self.num_total_cores // self.num_omp_threads == 0:
-            print('WARNING: Had fewer total number of cores than the default '
+            print('WARNING: Had fewer total number of cores than the '
                   f'number of OMP threads, using {self.num_total_cores} OMP '
                   f'threads')
             self.num_omp_threads = self.num_total_cores

--- a/reframe_config.py
+++ b/reframe_config.py
@@ -185,13 +185,20 @@ site_configuration = {
                     'prefix': '%(check_system)s/%(check_partition)s',
                     'level': 'info',
                     'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
+                        '%(check_job_completion_time)s|'
+                        'reframe %(version)s|'
+                        '%(check_info)s|'
+                        'jobid=%(check_jobid)s|'
                         '%(check_perf_var)s=%(check_perf_value)s|'
-                        'ref=%(check_perf_ref)s '
+                        'units=%(check_perf_unit)s|'
+                        'num_total_cores=%(check_num_total_cores)s|'
+                        'num_mpi_tasks=%(check_num_mpi_tasks)s|'
+                        'num_omp_threads=%(check_num_omp_threads)s|'
+                        'num_nodes=%(check_num_nodes)s|'
+                        'num_mpi_tasks_per_node=%(check_num_mpi_tasks_per_node)s|'
+                        'ref=%(check_perf_ref)s|'
                         '(l=%(check_perf_lower_thres)s, '
-                        'u=%(check_perf_upper_thres)s)|'
-                        '%(check_perf_unit)s'
+                        'u=%(check_perf_upper_thres)s)'
                     ),
                     'append': True
                 }


### PR DESCRIPTION
This PR includes a suggestion for a logging format along with a base test class, which all the ReFrame benchmarks could/should inherit from.

***
**Notes**

- The use of logged reframe variables (e.g. `x = variable(int, loggable=True)`) currently requires ReFrame [v3.11.0rc1](https://github.com/eth-cscs/reframe/releases/tag/v3.11.0-rc1), which is not pip-installable. Hopefully this feature will make its way into a properly released version soon. 
- Currently no benchmarks inherit from the base class (see https://github.com/t-young31/excalibur-tests/blob/main/apps/gromacs/benchmark.py for a full example)
- Scaling tests/benchmarks would require a something like [this](https://github.com/t-young31/excalibur-tests/blob/4f237b398772c98f3076698b067173bf9a16b510/modules/base_test.py#L65), as a _parameter_ cannot be a pre-defined _variable_.


Please feel free to add comments/suggestions or push to this branch 😄 