### PR TITLE
Disable views in Spack environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,13 @@ Here are the steps to create a Spack environment for a new system:
 
 * create the environment:
   ```
-  spack env create -d spack-environments/SYSTEM-NAME
+  spack env create --without-view -d spack-environments/SYSTEM-NAME
   ```
-  where `SYSTEM-NAME` is the same name as the ReFrame system name
+  where `SYSTEM-NAME` is the same name as the ReFrame system name.  Remember to
+  [disable
+  views](https://spack.readthedocs.io/en/latest/environments.html#filesystem-views)
+  with `--without-view` to avoid conflicts when installing incompatible packages
+  in the same environment
 * activate it:
   ```
   spack env activate -d spack-environments/SYSTEM-NAME
@@ -50,7 +54,7 @@ Here are the steps to create a Spack environment for a new system:
   "visible" (e.g., load the relevant modules) and add them to the environment
   with
   ```
-  spack external find --not-buildable PACKAGE-NAME ...
+  spack external find PACKAGE-NAME ...
   ```
   where `PACKAGE-NAME ...` are the names of the corresponding Spack packages
 * manually tweak the environment as necessary.  For example, if there is already

--- a/spack-environments/cosma8/spack.yaml
+++ b/spack-environments/cosma8/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: [sombrero@2021-08-16]
-  view: true
+  concretization: separately
+  view: false
   compilers:
   - compiler:
       spec: aocc@1.3.0

--- a/spack-environments/csd3/spack.yaml
+++ b/spack-environments/csd3/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: []
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack

--- a/spack-environments/dial3/spack.yaml
+++ b/spack-environments/dial3/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: [sombrero@2021-08-16]
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack

--- a/spack-environments/github-actions/spack.yaml
+++ b/spack-environments/github-actions/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: []
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack

--- a/spack-environments/isambard-cascadelake/spack.yaml
+++ b/spack-environments/isambard-cascadelake/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: []
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack

--- a/spack-environments/myriad/spack.yaml
+++ b/spack-environments/myriad/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: []
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack

--- a/spack-environments/tesseract/spack.yaml
+++ b/spack-environments/tesseract/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: []
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack

--- a/spack-environments/tursa/spack.yaml
+++ b/spack-environments/tursa/spack.yaml
@@ -5,7 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs: []
-  view: true
+  concretization: separately
+  view: false
   config:
     install_tree:
       root: opt/spack


### PR DESCRIPTION
Also, explicitly specify to concretize separately.  Note, that's the default
strategy, so it isn't fundamental to do this, but it's still useful to be
explicit, and also be safe against a change of the default strategy (as unlikely
as that is).

Fix #20