### PR TITLE
Add more fields to the perflog format

### DIFF
--- a/reframe_config.py
+++ b/reframe_config.py
@@ -267,13 +267,18 @@ site_configuration = {
                     'prefix': '%(check_system)s/%(check_partition)s',
                     'level': 'info',
                     'format': (
-                        '%(check_job_completion_time)s|reframe %(version)s|'
-                        '%(check_info)s|jobid=%(check_jobid)s|'
+                        '%(check_job_completion_time)s|'
+                        'reframe %(version)s|'
+                        '%(check_info)s|'
+                        'jobid=%(check_jobid)s|'
                         '%(check_perf_var)s=%(check_perf_value)s|'
-                        'ref=%(check_perf_ref)s '
-                        '(l=%(check_perf_lower_thres)s, '
-                        'u=%(check_perf_upper_thres)s)|'
-                        '%(check_perf_unit)s'
+                        'num_tasks=%(check_num_tasks)s|'
+                        'num_cpus_per_task=%(check_num_cpus_per_task)s|'
+                        'num_tasks_per_node=%(check_num_tasks_per_node)s|'
+                        'ref=%(check_perf_ref)s|'
+                        'lower=%(check_perf_lower_thres)s|'
+                        'upper=%(check_perf_upper_thres)s|'
+                        'units=%(check_perf_unit)s'
                     ),
                     'append': True
                 }


### PR DESCRIPTION
Taking the format from #19, without the base class (for the time being).  I only removed/renamed variables as per [this comment](https://github.com/ukri-excalibur/excalibur-tests/pull/19/commits/4f237b398772c98f3076698b067173bf9a16b510#r874654438) to stick to standard variables.  CC: @t-young31 