### PR TITLE
Automatically copy the Spack environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           git clone https://github.com/eth-cscs/reframe.git
           cd reframe
-          # In README.md we claim compatibility with at least v3.10.1, test that version.
-          git checkout v3.10.1
+          # In README.md we claim compatibility with at least v3.11.0, test that version.
+          git checkout v3.11.0
           ./bootstrap.sh
           echo "PATH=${PWD}/bin:${PATH}" >> "${GITHUB_ENV}"
       # Make sure `reframe` command works

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ create a very basic environment.
 
 [ReFrame](https://reframe-hpc.readthedocs.io/en/stable/) is a high-level
 framework for writing regression tests for HPC systems.  For our tests we
-require ReFrame 3.10.1.  Follow the [official
+require ReFrame 3.11.0.  Follow the [official
 instructions](https://reframe-hpc.readthedocs.io/en/stable/started.html) to
 install this package.  Note that ReFrame requires Python 3.6: in your HPC system
 you may need to load a specific module to have this version of Python available.

--- a/examples/sombrero/sombrero.py
+++ b/examples/sombrero/sombrero.py
@@ -28,7 +28,7 @@ class SpackSetup(rfm.RegressionTest):
     valid_systems = ['*']
     valid_prog_environs = ['default']
     executable = 'true'
-    spack_spec = variable(str, value='')
+    spack_spec = variable(str, value='', loggable=True)
 
     @run_before('compile')
     def setup_spack_environment(self):

--- a/examples/sombrero/sombrero.py
+++ b/examples/sombrero/sombrero.py
@@ -22,22 +22,37 @@ from modules.utils import identify_build_environment
 # * https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html
 #   (reference about the regression tests API)
 
+@rfm.simple_test
+class SpackSetup(rfm.RegressionTest):
+    build_system = 'Spack'
+    valid_systems = ['*']
+    valid_prog_environs = ['default']
+    executable = 'true'
+    spack_spec = variable(str, value='')
+
+    @run_before('compile')
+    def setup_spack_environment(self):
+        cp_dir, subdir = identify_build_environment(self.current_partition)
+        dest = path.join(self.stagedir, 'spack_env')
+        self.build_system.environment = path.join(dest, subdir)
+        self.prebuild_cmds = [f'cp -arv {cp_dir} {dest}']
+
+    @run_before('sanity')
+    def set_sanity_patterns(self):
+        self.sanity_patterns = sn.assert_true(1)
+
 # Class to define the benchmark.  See
 # https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html#the-reframe-module
 # for more information about the API of ReFrame tests.
 @rfm.simple_test
-class SombreroBenchmark(rfm.RegressionTest):
+class SombreroBenchmark(SpackSetup):
     # Systems and programming environments where to run this benchmark.  We
     # typically run them on all systems ('*'), unless there are particular
     # constraints.
-    valid_systems = ['*']
-    valid_prog_environs = ['default']
-    # The build system to use.  We always use Spack.
-    build_system = 'Spack'
     # Spack specification with default value.  A different value can be set
     # from the command line with `-S spack_spec='...'`:
     # https://reframe-hpc.readthedocs.io/en/stable/manpage.html#cmdoption-S
-    spack_spec = variable(str, value='sombrero@2021-08-16')
+    spack_spec = 'sombrero@2021-08-16'
     # Number of (MPI) tasks and CPUs per task.  Here we hard-code 1, but in
     # other cases you may want to use something different.  Note: ReFrame will
     # automatically launch MPI with the given number of tasks, using the
@@ -103,13 +118,7 @@ class SombreroBenchmark(rfm.RegressionTest):
 
     @run_before('compile')
     def setup_build_system(self):
-        # Spack spec(s) to install the desired package(s).  It is recommended
-        # to specify also the version number for reproducibility.
         self.build_system.specs = [self.spack_spec]
-        # Identify the Spack environment for the current system.  Keep this
-        # setting as is.
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
 
     # Function defining a sanity check.  See
     # https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html

--- a/examples/sombrero/sombrero.py
+++ b/examples/sombrero/sombrero.py
@@ -28,10 +28,14 @@ class SpackSetup(rfm.RegressionTest):
 
     @run_before('compile')
     def setup_spack_environment(self):
-        cp_dir, subdir = identify_build_environment(self.current_partition)
+        env_dir, cp_dir, subdir = identify_build_environment(
+            self.current_partition)
         dest = path.join(self.stagedir, 'spack_env')
         self.build_system.environment = path.join(dest, subdir)
-        self.prebuild_cmds = [f'cp -arv {cp_dir} {dest}']
+        self.prebuild_cmds = [
+            f'cp -arv {cp_dir} {dest}',
+            f'spack config add "config:install_tree:root:{env_dir}/opt/spack"',
+        ]
 
     # @run_before('sanity')
     # def set_sanity_patterns(self):

--- a/examples/sombrero/sombrero.py
+++ b/examples/sombrero/sombrero.py
@@ -22,12 +22,8 @@ from modules.utils import identify_build_environment
 # * https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html
 #   (reference about the regression tests API)
 
-@rfm.simple_test
 class SpackSetup(rfm.RegressionTest):
     build_system = 'Spack'
-    valid_systems = ['*']
-    valid_prog_environs = ['default']
-    executable = 'true'
     spack_spec = variable(str, value='', loggable=True)
 
     @run_before('compile')
@@ -37,9 +33,9 @@ class SpackSetup(rfm.RegressionTest):
         self.build_system.environment = path.join(dest, subdir)
         self.prebuild_cmds = [f'cp -arv {cp_dir} {dest}']
 
-    @run_before('sanity')
-    def set_sanity_patterns(self):
-        self.sanity_patterns = sn.assert_true(1)
+    # @run_before('sanity')
+    # def set_sanity_patterns(self):
+    #     self.sanity_patterns = sn.assert_true(1)
 
 # Class to define the benchmark.  See
 # https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html#the-reframe-module
@@ -49,6 +45,8 @@ class SombreroBenchmark(SpackSetup):
     # Systems and programming environments where to run this benchmark.  We
     # typically run them on all systems ('*'), unless there are particular
     # constraints.
+    valid_systems = ['*']
+    valid_prog_environs = ['default']
     # Spack specification with default value.  A different value can be set
     # from the command line with `-S spack_spec='...'`:
     # https://reframe-hpc.readthedocs.io/en/stable/manpage.html#cmdoption-S

--- a/examples/sombrero/sombrero.py
+++ b/examples/sombrero/sombrero.py
@@ -11,9 +11,10 @@ import reframe.utility.sanity as sn
 # Add top-level directory to `sys.path` so we can easily import extra modules
 # from any directory.
 sys.path.append(path.join(path.dirname(__file__), '..', '..'))
-# `identify_build_environment` will be used to identify the Spack environment
-# to be used when running the benchmark.
-from modules.utils import identify_build_environment
+# `SpackTest` is a class for benchmarks which will use Spack as build system.
+# The only requirement is to inherit this class and set the `spack_spec`
+# attribute.
+from modules.utils import SpackTest
 
 # See ReFrame documentation about writing tests for more details.  In
 # particular:
@@ -22,30 +23,11 @@ from modules.utils import identify_build_environment
 # * https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html
 #   (reference about the regression tests API)
 
-class SpackSetup(rfm.RegressionTest):
-    build_system = 'Spack'
-    spack_spec = variable(str, value='', loggable=True)
-
-    @run_before('compile')
-    def setup_spack_environment(self):
-        env_dir, cp_dir, subdir = identify_build_environment(
-            self.current_partition)
-        dest = path.join(self.stagedir, 'spack_env')
-        self.build_system.environment = path.join(dest, subdir)
-        self.prebuild_cmds = [
-            f'cp -arv {cp_dir} {dest}',
-            f'spack config add "config:install_tree:root:{env_dir}/opt/spack"',
-        ]
-
-    # @run_before('sanity')
-    # def set_sanity_patterns(self):
-    #     self.sanity_patterns = sn.assert_true(1)
-
 # Class to define the benchmark.  See
 # https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html#the-reframe-module
 # for more information about the API of ReFrame tests.
 @rfm.simple_test
-class SombreroBenchmark(SpackSetup):
+class SombreroBenchmark(SpackTest):
     # Systems and programming environments where to run this benchmark.  We
     # typically run them on all systems ('*'), unless there are particular
     # constraints.

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -220,7 +220,7 @@ def identify_build_environment(current_partition):
     # * if not, use a provided spack environment for the current partition
     # * if that doesn't exist, create a persistent minimal environment
     if os.getenv('EXCALIBUR_SPACK_ENV'):
-        cp_dir = os.getenv('EXCALIBUR_SPACK_ENV')
+        env_dir = cp_dir = os.getenv('EXCALIBUR_SPACK_ENV')
         subdir = ''
     else:
         system, partition = current_partition.fullname.split(':')
@@ -228,15 +228,15 @@ def identify_build_environment(current_partition):
             os.path.join(os.path.dirname(__file__), '..', 'spack-environments',
                          system))
         subdir = partition
+        env_dir = os.path.join(cp_dir, partition)
         if not os.path.isdir(cp_dir):
-            env = os.path.join(cp_dir, partition)
             cmd = run_command(["spack", "env", "create", "--without-view", "-d", env])
             if cmd.returncode != 0:
                 raise BuildSystemError("Creation of the Spack "
                                        f"environment {env} failed")
             getlogger().info("Spack environment successfully created at"
                              f"{env}")
-    return cp_dir, subdir
+    return env_dir, cp_dir, subdir
 
 if __name__ == '__main__':
 

--- a/reframe_config.py
+++ b/reframe_config.py
@@ -323,7 +323,8 @@ site_configuration = {
                         'ref=%(check_perf_ref)s|'
                         'lower=%(check_perf_lower_thres)s|'
                         'upper=%(check_perf_upper_thres)s|'
-                        'units=%(check_perf_unit)s'
+                        'units=%(check_perf_unit)s|'
+                        'spack_spec=%(check_spack_spec)s'
                     ),
                     'append': True
                 }


### PR DESCRIPTION
This lets us avoid touching the original Spack environment when running the
benchmarks.  The Spack spec can always be customised from the command line and its value will be recorded in the log, for future reference.