### PR TITLE
Use `SpackTest` in apps benchmarks

### DIFF
--- a/apps/cp2k/cp2k.py
+++ b/apps/cp2k/cp2k.py
@@ -9,13 +9,12 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 sys.path.append(path.join(path.dirname(__file__), '..', '..'))
-from modules.utils import identify_build_environment
+from modules.utils import SpackTest
 
-class Cp2kBaseBenchmark(rfm.RegressionTest):
+class Cp2kBaseBenchmark(SpackTest):
     valid_systems = ['*']
     valid_prog_environs = ['default']
-    build_system = 'Spack'
-    spack_spec = variable(str, value='cp2k@9.1')
+    spack_spec = 'cp2k@9.1'
     executable = 'cp2k.psmp'
     time_limit = '60m'
     num_cpus_per_task = 2
@@ -41,8 +40,6 @@ class Cp2kBaseBenchmark(rfm.RegressionTest):
     @run_before('compile')
     def setup_build_system(self):
         self.build_system.specs = [self.spack_spec]
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
 
     @run_before('sanity')
     def set_sanity_patterns(self):

--- a/apps/grid/grid.py
+++ b/apps/grid/grid.py
@@ -19,19 +19,16 @@ import sys
 import reframe as rfm
 import reframe.utility.sanity as sn
 sys.path.append(path.join(path.dirname(__file__), '..', '..'))
-from modules.utils import identify_build_environment
+from modules.utils import SpackTest
 
-class GridBenchmark(rfm.RegressionTest):
+class GridBenchmark(SpackTest):
     valid_systems = ['*']
     valid_prog_environs = ['default']
-    build_system = 'Spack'
-    spack_spec = variable(str, value='grid@develop')
+    spack_spec = 'grid@develop'
 
     @run_before('compile')
     def setup_build_system(self):
         self.build_system.specs = [self.spack_spec]
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
 
 
 @rfm.simple_test

--- a/apps/hpgmg/hpgmg.py
+++ b/apps/hpgmg/hpgmg.py
@@ -9,15 +9,14 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 sys.path.append(path.join(path.dirname(__file__), '..', '..'))
-from modules.utils import identify_build_environment
+from modules.utils import SpackTest
 
 
 @rfm.simple_test
-class HpgmgTest(rfm.RegressionTest):
+class HpgmgTest(SpackTest):
     valid_systems = ['*']
     valid_prog_environs = ['default']
-    build_system = 'Spack'
-    spack_spec = variable(str, value='hpgmg@0.4')
+    spack_spec = 'hpgmg@0.4'
     executable = 'hpgmg-fv'
     executable_opts = ['7', '8']
     num_tasks = 4
@@ -42,8 +41,6 @@ class HpgmgTest(rfm.RegressionTest):
     @run_before('compile')
     def setup_build_system(self):
         self.build_system.specs = [self.spack_spec]
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
 
     @run_before('sanity')
     def set_sanity_patterns(self):

--- a/apps/imb/imb.py
+++ b/apps/imb/imb.py
@@ -17,11 +17,11 @@ from collections import namedtuple
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from modules.imb import read_imb_out
 from modules.reframe_extras import ScalingTest
-from modules.utils import identify_build_environment
+from modules.utils import SpackTest
 
 Metric = namedtuple('Metric', ['column', 'function', 'unit', 'label'])
 
-class IMB_base(rfm.RegressionTest):
+class IMB_base(SpackTest):
     METRICS = []
 
     mpi_implementation = parameter(['openmpi','intel-mpi'])
@@ -31,7 +31,6 @@ class IMB_base(rfm.RegressionTest):
     perf_patterns = {} # must do this
     perf_patterns = {} # something funny about reframe's attr lookup
     executable = 'IMB-MPI1'
-    build_system = 'Spack'
     spack_spec = variable(str, value='intel-mpi-benchmarks@2019.6')
 
     def __init__(self):
@@ -40,7 +39,6 @@ class IMB_base(rfm.RegressionTest):
     @run_before('compile')
     def setup_build_system(self):
         self.build_system.specs = [self.spack_spec+'^'+self.mpi_implementation]
-        self.build_system.environment = identify_build_environment(self.current_partition)
 
     @run_before('performance')
     def add_metrics(self):

--- a/apps/sombrero/sombrero.py
+++ b/apps/sombrero/sombrero.py
@@ -12,21 +12,18 @@ import reframe.utility.udeps as udeps
 sys.path.append(path.join(path.dirname(__file__), '..', '..'))
 from apps.sombrero import case_filter
 from modules.reframe_extras import scaling_config
-from modules.utils import identify_build_environment
+from modules.utils import SpackTest
 
 
 @rfm.simple_test
-class SombreroBuild(rfm.CompileOnlyRegressionTest):
+class SombreroBuild(SpackTest, rfm.CompileOnlyRegressionTest):
     descr = "Build SOMBRERO"
     valid_systems = ['*']
     valid_prog_environs = ['default']
-    build_system = 'Spack'
-    spack_spec = variable(str, value='sombrero@2021-08-16')
+    spack_spec = 'sombrero@2021-08-16'
 
     @run_before('compile')
     def setup_build_system(self):
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
         self.build_system.specs = [self.spack_spec]
 
     @run_before('sanity')
@@ -35,19 +32,17 @@ class SombreroBuild(rfm.CompileOnlyRegressionTest):
 
 
 @rfm.simple_test
-class SombreroBenchmarkBase(rfm.RunOnlyRegressionTest):
+class SombreroBenchmarkBase(SpackTest, rfm.RunOnlyRegressionTest):
     valid_systems = []
     valid_prog_environs = ['default']
-    build_system = 'Spack'
     time_limit = '3m'
+    spack_spec = 'sombrero@2021-08-16'
     theory_id = parameter(range(1, 7))
 
     @run_after('init')
     def inject_dependencies(self):
         self.depends_on("SombreroBuild", udeps.fully)
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
-        self.build_system.specs = ['sombrero@2021-08-16']
+        self.build_system.specs = [self.spack_spec]
 
     @run_after('init')
     def set_executable(self):

--- a/apps/swift/swift.py
+++ b/apps/swift/swift.py
@@ -9,14 +9,13 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 sys.path.append(path.join(path.dirname(__file__), '..', '..'))
-from modules.utils import identify_build_environment
+from modules.utils import SpackTest
 
 @rfm.simple_test
-class SwiftBenchmark(rfm.RegressionTest):
+class SwiftBenchmark(SpackTest):
     valid_systems = ['*']
     valid_prog_environs = ['default']
-    build_system = 'Spack'
-    spack_spec = variable(str, value='swiftsim@0.9.0')
+    spack_spec = 'swiftsim@0.9.0'
     num_tasks = 4
     num_tasks_per_node = 1
     num_cpus_per_task = 8
@@ -55,8 +54,6 @@ class SwiftBenchmark(rfm.RegressionTest):
     @run_before('compile')
     def setup_build_system(self):
         self.build_system.specs = [self.spack_spec]
-        self.build_system.environment = identify_build_environment(
-            self.current_partition)
 
     @run_before('sanity')
     def set_sanity_patterns(self):


### PR DESCRIPTION
Follow up to #32: this PR actually uses the new `SpackTest` class in the real application tests.  I tried on CSD3 and Cosma with HPGMG, seems to be working fine