### PR TITLE
[cosma8] Fix processor configuration

### DIFF
--- a/reframe_config.py
+++ b/reframe_config.py
@@ -117,10 +117,10 @@ site_configuration = {
                     'environs': ['default', 'intel20-mpi-durham', 'intel20_u2-mpi-durham', 'intel19-mpi-durham', 'intel19_u3-mpi-durham'],
                     'max_jobs': 64,
                     'processor': {
-                        'num_cpus': 256,
-                        'num_cpus_per_core': 2,
+                        'num_cpus': 128,
+                        'num_cpus_per_core': 1,
                         'num_sockets': 2,
-                        'num_cpus_per_socket': 128,
+                        'num_cpus_per_socket': 64,
                     },
                 }
             ]


### PR DESCRIPTION
My understanding of https://www.dur.ac.uk/icc/cosma/support/cosma8/ is that each
node of Cosma8 has two sockets of [64-core AMD EPYC
7H12](https://en.wikichip.org/wiki/amd/epyc/7h12) CPUs, no hyperthreading.