### PR TITLE
[archer2] A few changes to the Spack environment

### DIFF
--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -193,6 +193,10 @@ spack:
       environment: {}
       extra_rpaths: []
   packages:
+    slurm:
+      externals:
+      - spec: slurm@21.08.8
+        prefix: /usr
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -233,6 +237,10 @@ spack:
         modules:
         - libfabric/1.11.0.4.71
         - cray-mpich/8.1.15
+    cray-pmi:
+      externals:
+      - spec: cray-pmi@6.1.1
+        prefix: /opt/cray/pe/pmi/6.1.1
     diffutils:
       externals:
       - spec: diffutils@3.6
@@ -287,6 +295,10 @@ spack:
         prefix: /opt/cray/pe/hdf5-parallel/1.12.0.3/gnu/9.1
         modules:
         - cray-hdf5-parallel/1.12.0.3
+    libfabric:
+      externals:
+      - spec: libfabric@1.11.0
+        prefix: /opt/cray/libfabric/1.11.0.4.71
     libtool:
       externals:
       - spec: libtool@2.4.6

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -219,9 +219,15 @@ spack:
         - cray-libsci/21.04.1.1
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.15
+      - spec: cray-mpich@8.1.15%cce
         prefix: /opt/cray/pe/mpich/8.1.15/ofi/crayclang/10.0
         modules:
+        - libfabric/1.11.0.4.71
+        - cray-mpich/8.1.15
+      - spec: cray-mpich@8.1.15%gcc
+        prefix: /opt/cray/pe/mpich/8.1.15/ofi/gnu/9.1
+        modules:
+        - libfabric/1.11.0.4.71
         - cray-mpich/8.1.15
     diffutils:
       externals:
@@ -251,16 +257,26 @@ spack:
         prefix: /usr
     gmp:
       externals:
-      - spec: gmp@6.2.1
+      - spec: gmp@6.2.1%cce
         prefix: /work/y07/shared/libs/core/gmp/6.2.1/CRAYCLANG/10.0
+      - spec: gmp@6.2.1%gcc
+        prefix: /work/y07/shared/libs/core/gmp/6.2.1/GNU/9.1
     hdf5:
       externals:
-      - spec: hdf5@1.12.0+cxx~mpi
+      - spec: hdf5@1.12.0+cxx~mpi%cce
         prefix: /opt/cray/pe/hdf5/1.12.0.3/crayclang/9.1
         modules:
         - cray-hdf5/1.12.0.3
-      - spec: hdf5@1.12.0+cxx+mpi^cray-mpich
+      - spec: hdf5@1.12.0+cxx+mpi^cray-mpich%cce
         prefix: /opt/cray/pe/hdf5-parallel/1.12.0.3/crayclang/9.1
+        modules:
+        - cray-hdf5-parallel/1.12.0.3
+      - spec: hdf5@1.12.0+cxx~mpi%gcc
+        prefix: /opt/cray/pe/hdf5/1.12.0.3/gnu/9.1
+        modules:
+        - cray-hdf5/1.12.0.3
+      - spec: hdf5@1.12.0+cxx+mpi^cray-mpich%gcc
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.0.3/gnu/9.1
         modules:
         - cray-hdf5-parallel/1.12.0.3
     libtool:

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -297,10 +297,6 @@ spack:
       externals:
       - spec: tar@1.30
         prefix: /usr
-    texinfo:
-      externals:
-      - spec: texinfo@6.5
-        prefix: /usr
     xz:
       externals:
       - spec: xz@5.2.3

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -132,10 +132,10 @@ spack:
   - compiler:
       spec: gcc@9.3.0
       paths:
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
+        cc: /opt/cray/pe/gcc/9.3.0/snos/bin/gcc
+        cxx: /opt/cray/pe/gcc/9.3.0/snos/bin/g++
+        f77: /opt/cray/pe/gcc/9.3.0/snos/bin/gfortran
+        fc: /opt/cray/pe/gcc/9.3.0/snos/bin/gfortran
       flags: {}
       operating_system: sles15
       target: any
@@ -147,10 +147,10 @@ spack:
   - compiler:
       spec: gcc@10.2.0
       paths:
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
+        cc: /opt/gcc/10.2.0/snos/bin/gcc
+        cxx: /opt/gcc/10.2.0/snos/bin/g++
+        f77: /opt/gcc/10.2.0/snos/bin/gfortran
+        fc: /opt/gcc/10.2.0/snos/bin/gfortran
       flags:
         fflags: -fallow-argument-mismatch
       operating_system: sles15
@@ -163,10 +163,10 @@ spack:
   - compiler:
       spec: gcc@10.3.0
       paths:
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
+        cc: /opt/cray/pe/gcc/10.3.0/snos/bin/gcc
+        cxx: /opt/cray/pe/gcc/10.3.0/snos/bin/g++
+        f77: /opt/cray/pe/gcc/10.3.0/snos/bin/gfortran
+        fc: /opt/cray/pe/gcc/10.3.0/snos/bin/gfortran
       flags:
         fflags: -fallow-argument-mismatch
       operating_system: sles15
@@ -179,10 +179,10 @@ spack:
   - compiler:
       spec: gcc@11.2.0
       paths:
-        cc: cc
-        cxx: CC
-        f77: ftn
-        fc: ftn
+        cc: /opt/cray/pe/gcc/11.2.0/snos/bin/gcc
+        cxx: /opt/cray/pe/gcc/11.2.0/snos/bin/g++
+        f77: /opt/cray/pe/gcc/11.2.0/snos/bin/gfortran
+        fc: /opt/cray/pe/gcc/11.2.0/snos/bin/gfortran
       flags:
         fflags: -fallow-argument-mismatch
       operating_system: sles15

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -227,6 +227,8 @@ spack:
       externals:
       - spec: diffutils@3.6
         prefix: /usr
+    fftw-api:
+      require: cray-fftw
     file:
       externals:
       - spec: file@5.32
@@ -247,6 +249,10 @@ spack:
       externals:
       - spec: gmake@4.2.1
         prefix: /usr
+    gmp:
+      externals:
+      - spec: gmp@6.2.1
+        prefix: /work/y07/shared/libs/core/gmp/6.2.1/CRAYCLANG/10.0
     hdf5:
       externals:
       - spec: hdf5@1.12.0+cxx~mpi
@@ -290,6 +296,10 @@ spack:
     tar:
       externals:
       - spec: tar@1.30
+        prefix: /usr
+    texinfo:
+      externals:
+      - spec: texinfo@6.5
         prefix: /usr
     xz:
       externals:

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -201,6 +201,10 @@ spack:
       externals:
       - spec: automake@1.15.1
         prefix: /usr
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
     cmake:
       externals:
       - spec: cmake@3.10.2
@@ -247,6 +251,10 @@ spack:
       externals:
       - spec: flex@2.6.4+lex
         prefix: /usr
+    gettext:
+      externals:
+      - spec: gettext@0.19.8.1
+        prefix: /usr
     git:
       externals:
       - spec: git@2.26.2~tcltk
@@ -283,19 +291,17 @@ spack:
       externals:
       - spec: libtool@2.4.6
         prefix: /usr
-    openssl:
-      externals:
-      - spec: openssl@1.1.0i-fips
-        prefix: /usr
-    python:
-      externals:
-      - spec: python@2.7.18+bz2+ctypes~dbm+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-        prefix: /usr
-      - spec: python@3.6.12+bz2+ctypes~dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-        prefix: /usr
     m4:
       externals:
       - spec: m4@1.4.18
+        prefix: /usr
+    openssh:
+      externals:
+      - spec: openssh@7.9p1
+        prefix: /usr
+    openssl:
+      externals:
+      - spec: openssl@1.1.0i-fips
         prefix: /usr
     perl:
       externals:
@@ -304,6 +310,12 @@ spack:
     pkg-config:
       externals:
       - spec: pkg-config@0.29.2
+        prefix: /usr
+    python:
+      externals:
+      - spec: python@2.7.18+bz2+ctypes~dbm+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
+        prefix: /usr
+      - spec: python@3.6.12+bz2+ctypes~dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
         prefix: /usr
     sed:
       externals:

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -193,10 +193,6 @@ spack:
       environment: {}
       extra_rpaths: []
   packages:
-    slurm:
-      externals:
-      - spec: slurm@21.08.8
-        prefix: /usr
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -327,11 +323,15 @@ spack:
       externals:
       - spec: python@2.7.18+bz2+ctypes~dbm+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
         prefix: /usr
-      - spec: python@3.6.12+bz2+ctypes~dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-        prefix: /usr
+      - spec: python@3.8.5+bz2+ctypes+dbm+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
+        prefix: /opt/cray/pe/python/3.8.5.0
     sed:
       externals:
       - spec: sed@4.4
+        prefix: /usr
+    slurm:
+      externals:
+      - spec: slurm@21.08.8
         prefix: /usr
     tar:
       externals:


### PR DESCRIPTION
See the individual commits for the changes done.  Main troubles I had for building Grid were

* compiling with gcc and using cray-mpich built with craylang (the fact that the modules have the same names is also a bit confusing)
* Cray wrappers for GCC caused lots of confusion for Spack (more specifically when trying to set `SPACK_COMPILER_IMPLICIT_RPATHS`), using the GCC binaries directly solved the issue

On this branch I was able to build `grid@develop%cce` and `grid@develop%gcc` without problems.