### PR TITLE
[imb] Avoid using Pandas

### DIFF
--- a/apps/imb/imb.py
+++ b/apps/imb/imb.py
@@ -19,7 +19,7 @@ from modules.imb import read_imb_out
 from modules.reframe_extras import ScalingTest
 from modules.utils import SpackTest
 
-Metric = namedtuple('Metric', ['column', 'function', 'unit', 'label'])
+Metric = namedtuple('Metric', ['column_number', 'function', 'unit', 'label'])
 
 class IMB_base(SpackTest):
     METRICS = []
@@ -50,22 +50,22 @@ class IMB_base(SpackTest):
         """
 
         for metric in self.METRICS:
-            self.perf_patterns[metric.label] = reduce(self.stdout, self.num_tasks, metric.column, metric.function)
+            self.perf_patterns[metric.label] = reduce(self.stdout, self.num_tasks, metric.column_number, metric.function)
             self.reference[metric.label] = (0, None, None, metric.unit)
 
 @sn.deferrable
-def reduce(path, n_procs, column, function):
+def reduce(path, n_procs, column_number, function):
     """ Calculate an aggregate value from IMB output.
 
         Args:
             path: str, path to file
             n_procs: int, number of processes
-            column: str, column name
+            column_number: int, column number
             function: callable to apply to specified `column` of table for `n_procs` in `path`
     """
     tables = read_imb_out(path)
     table = tables[n_procs] # separate lines here for more useful KeyError if missing:
-    col = table[column]
+    col = [row[column_number] for row in table]
     result = function(col)
     return result
 
@@ -73,10 +73,10 @@ def reduce(path, n_procs, column, function):
 class IMB_PingPong(IMB_base):
     """ Runs on 2 nodes """
     METRICS = [
-        # 'column' 'function', 'unit', 'label'
-        Metric('Mbytes/sec', max, 'Mbytes/sec', 'max_bandwidth'),
-        Metric('t[usec]', min, 't[usec]', 'min_latency'),
-        Metric('t[usec]', max, 't[usec]', 'max_latency'),
+        # 'column_number' 'function', 'unit', 'label'
+        Metric(3, max, 'Mbytes/sec', 'max_bandwidth'),
+        Metric(2, min, 't[usec]', 'min_latency'),
+        Metric(2, max, 't[usec]', 'max_latency'),
     ]
     def __init__(self):
         super().__init__()

--- a/apps/imb/imb.py
+++ b/apps/imb/imb.py
@@ -74,6 +74,8 @@ class IMB_PingPong(IMB_base):
     """ Runs on 2 nodes """
     METRICS = [
         # 'column_number' 'function', 'unit', 'label'
+        # Columns in the output of the benchmarks are:
+        #    #bytes | #repetitions | t[usec] | Mbytes/sec
         Metric(3, max, 'Mbytes/sec', 'max_bandwidth'),
         Metric(2, min, 't[usec]', 'min_latency'),
         Metric(2, max, 't[usec]', 'max_latency'),

--- a/modules/imb.py
+++ b/modules/imb.py
@@ -1,27 +1,25 @@
-import pandas as pd
-
 # examples of output - note that a single file *may* contain multiple
 # benchmark results
 #
-# # Benchmarking Uniband 
-# # #processes = 2 
+# # Benchmarking Uniband
+# # #processes = 2
 # #---------------------------------------------------
 #        #bytes #repetitions   Mbytes/sec      Msg/sec
 #             0         1000         0.00      2189915
 #
-# # Benchmarking PingPong 
-# # #processes = 2 
+# # Benchmarking PingPong
+# # #processes = 2
 # #---------------------------------------------------
 #        #bytes #repetitions      t[usec]   Mbytes/sec
 #             0         1000         2.25         0.00
 
 def read_imb_out(path):
     """ Read stdout from an IMB-MPI1 run.
-        
+
         Returns a dict with:
             key:= int, total number of processes involved
             value:= pandas dataframe, i.e. one per results table. Columns as per table.
-        
+
         If multiple results tables are present it is assumed that they are all the same benchmark,
         and only differ in the number of processes.
     """
@@ -49,15 +47,13 @@ def read_imb_out(path):
                 n_procs = int(line.split('=')[-1].strip())
                 while line.startswith('#'):
                     line = next(f) # may or may not include line "# .. additional processes waiting in MPI_Barrier", plus other # lines
-                cols = line.strip().split()
                 rows = []
                 while True:
                     line = next(f).strip()
                     if line == '':
                         break
-                    rows.append(f(v) for (f, v) in zip(converters, line.split()))
-                dframes[n_procs] = pd.DataFrame(rows, columns=cols)
-                #print('MAX %s: %s' % (n_procs, max(data['Mbytes/sec'])))
+                    rows.append([f(v) for (f, v) in zip(converters, line.split())])
+                dframes[n_procs] = rows
     return dframes
 
 if __name__ == '__main__':
@@ -65,4 +61,3 @@ if __name__ == '__main__':
     d = read_imb_out(sys.argv[1])
     for n, df in d.items():
         print(n)
-        


### PR DESCRIPTION
While a dataframe is a nicer datastructure for holding the data coming out of the IMB benchmarks, we don't really use dataframes features in any way and this needlessly put a requirement for `pandas` when running the benchmark.  We can easily live with a list of lists, without much effort (actually, with one or two lines less in total)

Fix #47.