### PR TITLE
[CI] Fix ReFrame configuration of GitHub Actions system

### DIFF
--- a/reframe_config.py
+++ b/reframe_config.py
@@ -186,7 +186,7 @@ site_configuration = {
                     'name': 'default',
                     'scheduler': 'local',
                     'launcher': 'mpirun',
-                    'environs': ['builtin']
+                    'environs': ['default']
                 }
             ]
         },  # End GitHub Actions


### PR DESCRIPTION
The environment `builtin` doesn't exist anymore, it's called `default` now. This mismatch caused the benchmark not to actually run on CI.