### PR TITLE
Expand spack environment for Myriad

### DIFF
--- a/spack-environments/myriad/compute-node/spack.yaml
+++ b/spack-environments/myriad/compute-node/spack.yaml
@@ -111,6 +111,10 @@ spack:
       externals:
       - spec: automake@1.13.4
         prefix: /usr
+    binutils:
+      externals:
+      - spec: binutils@2.27.43
+        prefix: /usr
     bzip2:
       externals:
       - spec: bzip2@1.0.6
@@ -121,10 +125,52 @@ spack:
         prefix: /shared/ucl/apps/cmake/3.21.1/gnu-4.9.2
       - spec: cmake@2.8.12.2
         prefix: /usr
+    coreutils:
+      externals:
+      - spec: coreutils@8.22
+        prefix: /usr
+    curl:
+      externals:
+      - spec: curl@7.29.0+ldap
+        prefix: /usr
+    diffutils:
+      externals:
+      - spec: diffutils@3.3
+        prefix: /usr
+    findutils:
+      externals:
+      - spec: findutils@4.5.11
+        prefix: /usr
+    flex:
+      externals:
+      - spec: flex@2.5.39~lex
+        prefix: /shared/ucl/apps/flex/2.5.39/gnu-4.9.2
+    gawk:
+      externals:
+      - spec: gawk@4.0.2
+        prefix: /usr
     gettext:
       externals:
       - spec: gettext@0.19.8.1
         prefix: /usr
+    git:
+      externals:
+      - spec: git@2.32.0+tcltk
+        prefix: /shared/ucl/apps/git/2.32.0/gnu-4.9.2
+      - spec: git@1.8.3.1~tcltk
+        prefix: /usr
+    gmake:
+      externals:
+      - spec: gmake@3.82
+        prefix: /usr
+    groff:
+      externals:
+      - spec: groff@1.22.2
+        prefix: /usr
+    hwloc:
+      externals:
+      - spec: hwloc@1.11.12
+        prefix: /shared/ucl/apps/hwloc/1.11.12
     intel-mpi:
       externals:
       - spec: intel-mpi@2020.0.166
@@ -133,6 +179,10 @@ spack:
       externals:
       - spec: libtool@2.4.3
         prefix: /usr
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.4
+        prefix: /shared/ucl/apps/libxml2/2.9.4/gnu-4.9.2
     libxsmm:
       externals:
       - spec: libxsmm@1.16.1
@@ -141,15 +191,47 @@ spack:
       externals:
       - spec: m4@1.4.16
         prefix: /usr
+    ninja:
+      externals:
+      - spec: ninja@1.10.2.git.kitware.jobserver-1
+        prefix: /shared/ucl/apps/python/bundles/python39-6.0.0/venv
+    numactl:
+      externals:
+      - spec: numactl@2.0.12
+        prefix: /shared/ucl/apps/numactl/2.0.12
     openmpi:
       externals:
       - spec: openmpi@4.0.3%gcc@4.9.2
         prefix: /shared/ucl/apps/openmpi/4.0.3/gnu-4.9.2
+    openssh:
+      externals:
+      - spec: openssh@7.4p1
+        prefix: /usr
+    openssl:
+      externals:
+      - spec: openssl@1.0.2k-fips
+        prefix: /usr
     perl:
       externals:
       - spec: perl@5.16.3~cpanm+shared+threads
         prefix: /usr
+    pkg-config:
+      externals:
+      - spec: pkg-config@0.27.1
+        prefix: /usr
     python:
       externals:
-      - spec: python@2.7.5+bz2+ctypes+dbm+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
+      - spec: python@2.7.5+bz2+crypt+ctypes+dbm+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
+        prefix: /usr
+    subversion:
+      externals:
+      - spec: subversion@1.14.1
+        prefix: /shared/ucl/apps/subversion/1.14.1
+    tar:
+      externals:
+      - spec: tar@1.26
+        prefix: /usr
+    texinfo:
+      externals:
+      - spec: texinfo@5.1
         prefix: /usr


### PR DESCRIPTION
Note: system `python@3` doesn't seem to be usable by spack because libpython is only found via `LD_LIBRARY_PATH`, not rpath/runpath.