### PR TITLE
[Spack] Make MPI packages not buildable

### DIFF
--- a/spack-environments/common.yaml
+++ b/spack-environments/common.yaml
@@ -3,3 +3,6 @@ concretizer:
 config:
   install_tree:
     root: opt/spack
+packages:
+  mpi:
+    buildable: false


### PR DESCRIPTION
This forces to always use packages already available in the environment.