### PR TITLE
[spack] Move `intall_tree` option back to individual files

### DIFF
--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/common.yaml
+++ b/spack-environments/common.yaml
@@ -1,8 +1,5 @@
 concretizer:
   unify: false
-config:
-  install_tree:
-    root: opt/spack
 packages:
   mpi:
     buildable: false

--- a/spack-environments/cosma8/compute-node/spack.yaml
+++ b/spack-environments/cosma8/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/csd3-icelake/compute-node/spack.yaml
+++ b/spack-environments/csd3-icelake/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/csd3-skylake/compute-node/spack.yaml
+++ b/spack-environments/csd3-skylake/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/dial3/compute-node/spack.yaml
+++ b/spack-environments/dial3/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/github-actions/default/spack.yaml
+++ b/spack-environments/github-actions/default/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/isambard-a64fx/compute-node/spack.yaml
+++ b/spack-environments/isambard-a64fx/compute-node/spack.yaml
@@ -6,11 +6,11 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: true
-  concretizer:
-    unify: false
   config:
     install_tree:
       root: opt/spack
+  include:
+  - ../../common.yaml
   compilers:
   - compiler:
       spec: cce@10.0.3

--- a/spack-environments/isambard-cascadelake/compute-node/spack.yaml
+++ b/spack-environments/isambard-cascadelake/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/myriad/compute-node/spack.yaml
+++ b/spack-environments/myriad/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/tesseract/compute-node/spack.yaml
+++ b/spack-environments/tesseract/compute-node/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/tursa/cpu/spack.yaml
+++ b/spack-environments/tursa/cpu/spack.yaml
@@ -6,6 +6,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
+  config:
+    install_tree:
+      root: opt/spack
   include:
   - ../../common.yaml
   compilers:


### PR DESCRIPTION
Unfortunately the root of the install tree seems to be relative to the file where the configuration is written, rather than the main `spack.yaml` file, so it's not really possible to share this option among all configurations.