### PR TITLE
Add Isambard XCI partition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,15 @@ more details, or see the examples of the existing systems.  Note: you likely do
 not need to customise the programming environment in ReFrame, as we will use
 Spack as build system, which will deal with that.
 
+If available, the command `lscpu`, run on a compute node, is typically useful to
+get information about the CPUs, to be used in the `processor` item of the system
+configuration.  The numbers you need to watch out for are:
+
+* "CPU(s)", (`num_cpus` in ReFrame configuration),
+* "Thread(s) per core", (`num_cpus_per_core`),
+* "Socket(s)", (`num_sockets`),
+* "Core(s) per socket", (`num_cpus_per_socket`).
+
 ### Spack configuration
 
 When using Spack as build system, ReFrame needs a [Spack

--- a/examples/sombrero/sombrero.py
+++ b/examples/sombrero/sombrero.py
@@ -86,6 +86,9 @@ class SombreroBenchmark(SpackTest):
         'github-actions': {
             'flops': (0.9, None, None, 'Gflops/seconds'),
         },
+        'isambard-xci': {
+            'flops': (0.6, -0.2, None, 'Gflops/seconds'),
+        },
         'myriad': {
             'flops': (1, -0.2, None, 'Gflops/seconds'),
         },

--- a/reframe_config.py
+++ b/reframe_config.py
@@ -177,6 +177,29 @@ site_configuration = {
             ]
         },  # end Isambard A64FX
         {
+            # https://gw4-isambard.github.io/docs/user-guide/XCI.html
+            'name': 'isambard-xci',
+            'descr': 'XCI - Marvell Thunder X2 nodes of Isambard 2',
+            'hostnames': ['xcil0[0-1]'],
+            'partitions': [
+                {
+                    'name': 'compute-node',
+                    'descr': 'XCI computing nodes',
+                    'scheduler': 'pbs',
+                    'launcher': 'alps',
+                    'access': ['-q arm'],
+                    'environs': ['default'],
+                    'max_jobs': 20,
+                    'processor': {
+                        'num_cpus': 256,
+                        'num_cpus_per_core': 4,
+                        'num_sockets': 2,
+                        'num_cpus_per_socket': 128,
+                    },
+                },
+            ]
+        },  # end Isambard A64FX
+        {
             # https://www.dur.ac.uk/icc/cosma/support/cosma8/
             'name': 'cosma8',
             'descr': 'COSMA',

--- a/spack-environments/isambard-xci/compute-node/spack.yaml
+++ b/spack-environments/isambard-xci/compute-node/spack.yaml
@@ -1,0 +1,310 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs: []
+  view: false
+  config:
+    install_tree:
+      root: opt/spack
+  include:
+  - ../../common.yaml
+  compilers:
+  - compiler:
+      spec: cce@9.1.3
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-cray
+      - cce/9.1.3
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: cce@11.0.4
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-cray
+      - cce/11.0.4
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@7.3.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/7.3.0
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@8.3.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/8.3.0
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.3.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/9.3.0
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@8.1.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/8.1.0
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.2.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/9.2.0
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@10.3.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: cnl7
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/10.3.0
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@10.3.0
+      paths:
+        cc: /opt/gcc/10.3.0/bin/gcc
+        cxx: /opt/gcc/10.3.0/bin/g++
+        f77: /opt/gcc/10.3.0/bin/gfortran
+        fc: /opt/gcc/10.3.0/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@7.3.0
+      paths:
+        cc: /opt/gcc/7.3.0/bin/gcc
+        cxx: /opt/gcc/7.3.0/bin/g++
+        f77: /opt/gcc/7.3.0/bin/gfortran
+        fc: /opt/gcc/7.3.0/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@7.5.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: null
+        fc: null
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@8.1.0
+      paths:
+        cc: /opt/gcc/8.1.0/bin/gcc
+        cxx: /opt/gcc/8.1.0/bin/g++
+        f77: /opt/gcc/8.1.0/bin/gfortran
+        fc: /opt/gcc/8.1.0/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@8.3.0
+      paths:
+        cc: /opt/gcc/8.3.0/bin/gcc
+        cxx: /opt/gcc/8.3.0/bin/g++
+        f77: /opt/gcc/8.3.0/bin/gfortran
+        fc: /opt/gcc/8.3.0/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.2.0
+      paths:
+        cc: /opt/gcc/9.2.0/bin/gcc
+        cxx: /opt/gcc/9.2.0/bin/g++
+        f77: /opt/gcc/9.2.0/bin/gfortran
+        fc: /opt/gcc/9.2.0/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.3.0
+      paths:
+        cc: /opt/gcc/9.3.0/bin/gcc
+        cxx: /opt/gcc/9.3.0/bin/g++
+        f77: /opt/gcc/9.3.0/bin/gfortran
+        fc: /opt/gcc/9.3.0/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  packages:
+    autoconf:
+      externals:
+      - spec: autoconf@2.69
+        prefix: /usr
+    automake:
+      externals:
+      - spec: automake@1.15.1
+        prefix: /usr
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /usr
+    cmake:
+      externals:
+      - spec: cmake@3.10.2
+        prefix: /usr
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@7.7.17%cce
+        prefix: /opt/cray/pe/mpt/7.7.17/gni/mpich-crayclang/10.0
+        modules:
+        - cray-mpich/7.7.17
+      - spec: cray-mpich@7.7.17%gcc
+        prefix: /opt/cray/pe/mpt/7.7.17/gni/mpich-gnu/8.2
+        modules:
+        - cray-mpich/7.7.17
+    diffutils:
+      externals:
+      - spec: diffutils@3.6
+        prefix: /usr
+    findutils:
+      externals:
+      - spec: findutils@4.6.0
+        prefix: /usr
+    gettext:
+      externals:
+      - spec: gettext@0.19.8.1
+        prefix: /usr
+    libtool:
+      externals:
+      - spec: libtool@2.4.6
+        prefix: /usr
+    m4:
+      externals:
+      - spec: m4@1.4.18
+        prefix: /usr
+    openssh:
+      externals:
+      - spec: openssh@7.9p1
+        prefix: /usr
+    openssl:
+      externals:
+      - spec: openssl@1.1.0i-fips
+        prefix: /usr
+    perl:
+      externals:
+      - spec: perl@5.26.1~cpanm+open+shared+threads
+        prefix: /usr
+    python:
+      externals:
+      - spec: python@3.8.5+bz2+crypt+ctypes+dbm+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+        prefix: /opt/python/3.8.5.1
+      - spec: python@3.7.3+bz2+crypt+ctypes+dbm+lzma~nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+        prefix: /opt/python/3.7.3.2
+      - spec: python@2.7.18+bz2+crypt+ctypes~dbm~lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib
+        prefix: /usr
+      - spec: python@3.6.12+bz2+crypt+ctypes~dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib
+        prefix: /usr
+    tar:
+      externals:
+      - spec: tar@1.30
+        prefix: /usr
+    texinfo:
+      externals:
+      - spec: texinfo@6.5
+        prefix: /usr
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr


### PR DESCRIPTION
I only tested the simple Sombrero example, and that one worked straight away:
```console
> reframe -c examples/sombrero/ -r --performance-report --system isambard-xci
[ReFrame Setup]
  version:           3.12.0
  command:           '/home/ri-mgiordano/repo/reframe/bin/reframe -c examples/sombrero/ -r --performance-report --system isambard-xci'
  launched by:       ri-mgiordano@xcil00
  working directory: '/lustre/home/ri-mgiordano/repo/excalibur-tests'
  settings file:     '/home/ri-mgiordano/repo/excalibur-tests/reframe_config.py'
  check search path: '/lustre/home/ri-mgiordano/repo/excalibur-tests/examples/sombrero'
  stage directory:   '/lustre/home/ri-mgiordano/repo/excalibur-tests/stage'
  output directory:  '/lustre/home/ri-mgiordano/repo/excalibur-tests/output'

[==========] Running 1 check(s)
[==========] Started on Fri Feb  3 15:01:38 2023 

[----------] start processing checks
[ RUN      ] SombreroBenchmark @isambard-xci:compute-node+default
[       OK ] (1/1) SombreroBenchmark @isambard-xci:compute-node+default
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
[==========] Finished on Fri Feb  3 15:03:08 2023 
==============================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------
SombreroBenchmark
- isambard-xci:compute-node
   - default
      * num_tasks: 1
      * flops: 0.66 Gflops/seconds
------------------------------------------------------------------------------
Run report saved in '/home/ri-mgiordano/.reframe/reports/run-report.json'
Log file(s) saved in '/tmp/rfm-hyvqake3.log'
```

Haven't tested anything else yet.

Ref #78.