### PR TITLE
Add documentation about system-specific details

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ reframe -c apps/sombrero -r --performance-report -S spack_spec='sombrero@2021-08
 Note that the `-S` option can be used to set from the command line on a per-job
 basis the built-in fields of ReFrame regressions classes, e.g.
 [`variables`](https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html#reframe.core.pipeline.RegressionTest.variables),
-which controls the environment variables used in a job.  For example
+which controls the environment variables used in a job.
+The syntax to set dictionary items, like for `variables`, is a comma-separated list of `key:value` pairs: `-S dict=key_1:value_1,key_2:value_2`.
+For example
 
 ```
 reframe -c apps/sombrero -r --performance-report -S variables=OMP_PLACES:threads
@@ -159,9 +161,13 @@ the "generic" system, a new empty Spack environment will be automatically create
 different Spack environment by setting the environment variable `EXCALIBUR_SPACK_ENV`
 described above.
 
-## Contributing new systems or benchmarks and other information
+### System-specific flags
+
+While the aim is to automate as much system-specific configuration as possible, there are some options that have to be provided by the user, such as accounting details, and unfortunately the syntax can vary.
+The file [`SYSTEMS.md`](./SYSTEMS.md) contains information about the use of this framework on specific systems.
+
+## Contributing new systems or benchmarks
 
 Feel free to add new benchmark apps or support new systems that are part of the
 ExCALIBUR benchmarking collaboration.  Read
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more details.
-The file [`SYSTEMS.md`](./SYSTEMS.md) contains information about the use of this framework on specific systems.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ the `spack_spec` variable:
 reframe -c apps/sombrero -r --performance-report -S spack_spec='sombrero@2021-08-16%intel'
 ```
 
-Note that the `-S` option can be used to set from the command line on a per-job
+### Setting environment variables
+
+The `-S` option can be used to set from the command line on a per-job
 basis the built-in fields of ReFrame regressions classes, e.g.
 [`variables`](https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html#reframe.core.pipeline.RegressionTest.variables),
 which controls the environment variables used in a job.

--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ the "generic" system, a new empty Spack environment will be automatically create
 different Spack environment by setting the environment variable `EXCALIBUR_SPACK_ENV`
 described above.
 
-## Contributing new systems or benchmarks
+## Contributing new systems or benchmarks and other information
 
 Feel free to add new benchmark apps or support new systems that are part of the
 ExCALIBUR benchmarking collaboration.  Read
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more details.
+The file [`SYSTEMS.md`](./SYSTEMS.md) contains information about the use of this framework on specific systems.

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -25,7 +25,8 @@ reframe -c examples/sombrero -r --performance-report --system archer2 -J'--qos=s
 ### Controlling CPU frequency
 
 ARCHER2 allows [choosing the CPU frequency](https://docs.archer2.ac.uk/user-guide/energy/#controlling-cpu-frequency) during jobs by setting the environment variable `SLURM_CPU_FREQ_REQ` to specific values.
-In ReFrame v3 the list of environment variables set by the framework is hold by the dictionary attribute called `variables`, and you can initialise it on the command line when running a benchmark with `-S`/`--setvar`.
+In ReFrame v3 the list of environment variables set by the framework is held by the dictionary attribute called `variables`, and you can initialise it on the command line when running a benchmark with `-S`/`--setvar`.
+For more details, see Setting environment variables in [`README.md`](./README.md).
 For example, to submit a benchmark using the lowest CPU frequency (1.5 GHz) you can use
 
 ```

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -59,6 +59,19 @@ reframe -c examples/sombrero -r --performance-report --system dial3:compute-node
 
 where `<ACCOUNT>` is the project you want to charge.
 
+## Isambard 2
+
+### Cascadelake partition
+
+#### Compilation on compute node
+
+There is no Cascadelake login node on Isambard 2.
+To run compilation on the compute node, you have to set the attribute [`build_locally`](https://reframe-hpc.readthedocs.io/en/stable/regression_test_api.html#reframe.core.pipeline.RegressionTest.build_locally) to `false` with `-S build_locally=false`:
+
+```
+reframe -c examples/sombrero -r --performance-report --system isambard-cascadelake:compute-node -S build_locally=false
+```
+
 ## Myriad
 
 ### Python3 module

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -22,13 +22,10 @@ reframe -c examples/sombrero -r --performance-report --system archer2 -J'--qos=s
 reframe -c examples/sombrero -r --performance-report --system archer2 -J'--qos=short' -J'--account=t01'
 ```
 
-Note that jobs run on specific queues, like `serial` and `lowpriority`, do not charge the corresponding project, but you need to have at least 1 [Computing Resource (CU)](https://docs.archer2.ac.uk/user-guide/scheduler/#cus) in budget to access them.
-
 ### Controlling CPU frequency
 
 ARCHER2 allows [choosing the CPU frequency](https://docs.archer2.ac.uk/user-guide/energy/#controlling-cpu-frequency) during jobs by setting the environment variable `SLURM_CPU_FREQ_REQ` to specific values.
 In ReFrame v3 the list of environment variables set by the framework is hold by the dictionary attribute called `variables`, and you can initialise it on the command line when running a benchmark with `-S`/`--setvar`.
-The syntax to set dictionary items is a comma-separated list of `key:value` pairs: `-S dict=key_1:value_1,key_2:value_2`
 For example, to submit a benchmark using the lowest CPU frequency (1.5 GHz) you can use
 
 ```
@@ -57,7 +54,7 @@ When submitting jobs to compute nodes, you need to specify the job queue, with t
 To do this, when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to specify the account, for example:
 
 ```
-reframe -c examples/sombrero -r --performance-report --system csd3-skylake:compute-node -J'--accout=<ACCOUNT>'
+reframe -c examples/sombrero -r --performance-report --system dial3:compute-node -J'--accout=<ACCOUNT>'
 ```
 
 where `<ACCOUNT>` is the project you want to charge.

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -1,0 +1,117 @@
+# System-specific information
+
+This framework strives to be as system-independent as possible, but there are some platform-specific details that you may need be aware of when running these benchmarks.
+Below we collect some information you may want to keep in mind on the different systems.
+
+## ARCHER2
+
+### Home partition
+
+ARCHER2 uses the standard Cray setup for which the home partition is ***not*** mounted on compute nodes, read [Data management and transfer](https://docs.archer2.ac.uk/user-guide/data/) for more details.
+You likely want to install this benchmarking framework outside of your home directory, for example inside `/work/<project code>/<project code>/${USER}`, where `<project code>` is your project code.
+
+### Queue options
+
+When submitting jobs to compute nodes, you need to specify the job queue and maybe the project account.
+The former is specified by setting the [Quality of Service](https://docs.archer2.ac.uk/user-guide/scheduler/#quality-of-service-qos), the latter is necessary if your user account is associated to multiple projects on ARCHER2 and you need to [specify which one to use](https://docs.archer2.ac.uk/user-guide/scheduler/#specifying-resources-in-job-scripts) for the submitted jobs.
+We cannot automatically set these options for you because they are user-specific, but when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to add new job options.
+Some examples:
+
+```
+reframe -c examples/sombrero -r --performance-report --system archer2 -J'--qos=serial'
+reframe -c examples/sombrero -r --performance-report --system archer2 -J'--qos=short' -J'--account=t01'
+```
+
+Note that jobs run on specific queues, like `serial` and `lowpriority`, do not charge the corresponding project, but you need to have at least 1 [Computing Resource (CU)](https://docs.archer2.ac.uk/user-guide/scheduler/#cus) in budget to access them.
+
+### Controlling CPU frequency
+
+ARCHER2 allows [choosing the CPU frequency](https://docs.archer2.ac.uk/user-guide/energy/#controlling-cpu-frequency) during jobs by setting the environment variable `SLURM_CPU_FREQ_REQ` to specific values.
+In ReFrame v3 the list of environment variables set by the framework is hold by the dictionary attribute called `variables`, and you can initialise it on the command line when running a benchmark with `-S`/`--setvar`.
+The syntax to set dictionary items is a comma-separated list of `key:value` pairs: `-S dict=key_1:value_1,key_2:value_2`
+For example, to submit a benchmark using the lowest CPU frequency (1.5 GHz) you can use
+
+```
+reframe -c examples/sombrero -r --performance-report --system archer2 -J'--qos=serial' -S variables=SLURM_CPU_FREQ_REQ:1500000
+```
+
+## CSD3
+
+### Queue options
+
+When submitting jobs to compute nodes, you need to specify the job queue, with the `--account` option to the scheduler.
+To do this, when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to specify the account, for example:
+
+```
+reframe -c examples/sombrero -r --performance-report --system csd3-skylake:compute-node -J'--accout=<ACCOUNT>'
+```
+
+where `<ACCOUNT>` is the project you want to charge.
+You can see the account balance of your projects with the `mybalance` command.
+
+## DIaL3
+
+### Queue options
+
+When submitting jobs to compute nodes, you need to specify the job queue, with the `--account` option to the scheduler.
+To do this, when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to specify the account, for example:
+
+```
+reframe -c examples/sombrero -r --performance-report --system csd3-skylake:compute-node -J'--accout=<ACCOUNT>'
+```
+
+where `<ACCOUNT>` is the project you want to charge.
+
+## Myriad
+
+### Python3 module
+
+The only default Python in the system is currently Python 2.7, but this may change in the future.
+Both ReFrame v3 and Spack v0.20 require Python v3.6 (at the moment most benchmarks should work also with Spack v0.18, but newer recipes may only be available in more recent versions of Spack), so you need to have a Python 3.6 available.
+This is provided by the `python3` module in the system, the easiest thing to do is to add the lines
+
+```sh
+module load python3
+export RFM_USE_LOGIN_SHELL="True"
+```
+
+to your shell init script (e.g. `~/.bashrc`).
+The second line tells ReFrame to always load the shell init script when running the jobs, so that the Python3 module is available also during the jobs, to run Spack.
+
+### Temporary directory for building packages with Spack
+
+Before moving it to the final installation place, Spack builds software in a temporary directory.
+By default on Myriad this is `/tmp`, but this directory is shared with other users and its partition is relatively small, so that building large software may always end up filling the entire disk, resulting in frequent `No space left on device` errors.
+To work around this issue you can use as temporary directory the one pointed to by `XDG_RUNTIME_DIR`, which use a larger partition, reserved only to your user.
+Note that this directory is automatically cleaned up after you log all of your sessions out of the system.
+You can add the following line to your shell init script (e.g., `~/.bashrc`) to make `TMPDIR` use `XDG_RUNTIME_DIR`, unless otherwise set:
+
+```sh
+export TMPDIR="${TMPDIR:-${XDG_RUNTIME_DIR:-/tmp}}"
+```
+
+## Tesseract
+
+### Queue options
+
+When submitting jobs to compute nodes, you need to specify the job queue, with the `--account` option to the scheduler.
+To do this, when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to specify the account, for example:
+
+```
+reframe -c examples/sombrero -r --performance-report --system tesseract:compute-node -J'--accout=<ACCOUNT>'
+```
+
+where `<ACCOUNT>` is the project you want to charge.
+
+## Tursa
+
+### Queue options
+
+When submitting jobs to compute nodes, you need to specify the job queue, with the `--account` option to the scheduler.
+To do this, when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to specify the account, for example:
+
+```
+reframe -c examples/sombrero -r --performance-report --system tursa:compute-node -J'--accout=<ACCOUNT>'
+```
+
+where `<ACCOUNT>` is the project you want to charge.


### PR DESCRIPTION
Ref #46.  I started with ARCHER2 and Myriad, as they are the systems I used most recently, but I will add information about the others as I remember what we need to do there (often need to specify a job queue or user account).