### PR TITLE
[spack] Move `intall_tree` option back to common file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Here are the steps to create a Spack environment for a new system:
 * set the
   [`install_tree`](https://spack.readthedocs.io/en/latest/config_yaml.html#install-tree):
   ```
-  spack config add 'config:install_tree:root:opt/spack'
+  spack config add 'config:install_tree:root:$env/opt/spack'
   ```
 * make sure the compilers you want to add are in the `PATH` (e.g., load the
   relevant modules), then add them to the Spack environment with:

--- a/spack-environments/archer2/compute-node/spack.yaml
+++ b/spack-environments/archer2/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/common.yaml
+++ b/spack-environments/common.yaml
@@ -3,3 +3,6 @@ concretizer:
 packages:
   mpi:
     buildable: false
+config:
+  install_tree:
+    root: $env/opt/spack

--- a/spack-environments/cosma8/compute-node/spack.yaml
+++ b/spack-environments/cosma8/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/csd3-icelake/compute-node/spack.yaml
+++ b/spack-environments/csd3-icelake/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/csd3-skylake/compute-node/spack.yaml
+++ b/spack-environments/csd3-skylake/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/dial3/compute-node/spack.yaml
+++ b/spack-environments/dial3/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/github-actions/default/spack.yaml
+++ b/spack-environments/github-actions/default/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/isambard-a64fx/compute-node/spack.yaml
+++ b/spack-environments/isambard-a64fx/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: true
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/isambard-cascadelake/compute-node/spack.yaml
+++ b/spack-environments/isambard-cascadelake/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/isambard-xci/compute-node/spack.yaml
+++ b/spack-environments/isambard-xci/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/myriad/compute-node/spack.yaml
+++ b/spack-environments/myriad/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/tesseract/compute-node/spack.yaml
+++ b/spack-environments/tesseract/compute-node/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:

--- a/spack-environments/tursa/cpu/spack.yaml
+++ b/spack-environments/tursa/cpu/spack.yaml
@@ -6,9 +6,6 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: false
-  config:
-    install_tree:
-      root: opt/spack
   include:
   - ../../common.yaml
   compilers:


### PR DESCRIPTION
While looking into https://github.com/ukri-excalibur/excalibur-tests/pull/85#issuecomment-1429519523 I found the [Spack-specific variable](https://spack.readthedocs.io/en/latest/configuration.html#spack-specific-variables) `$env`, which allows us to reference the path to the active environment in the common file `common.yaml`, so that we can have again the `install_tree` setting in the common file.  This more or less reverts  #75, but now we have better solution.