### PR TITLE
[Isambard-a64fx] Force compilation for A64FX in Spack

### DIFF
--- a/spack-environments/isambard-a64fx/compute-node/spack.yaml
+++ b/spack-environments/isambard-a64fx/compute-node/spack.yaml
@@ -8,6 +8,9 @@ spack:
   view: true
   include:
   - ../../common.yaml
+  concretizer:
+    targets:
+      host_compatible: False
   compilers:
   - compiler:
       spec: cce@10.0.3
@@ -81,6 +84,8 @@ spack:
       environment: {}
       extra_rpaths: []
   packages:
+    all:
+      require: 'target=a64fx'
     autoconf:
       externals:
       - spec: autoconf@2.69


### PR DESCRIPTION
Spack currently misdetects Isambard A64FX as a generci Aarch64 target.  This change forces the compilation for A64FX.