### PR TITLE
Shorten path of install tree

### DIFF
--- a/spack-environments/common.yaml
+++ b/spack-environments/common.yaml
@@ -5,4 +5,4 @@ packages:
     buildable: false
 config:
   install_tree:
-    root: $env/opt/spack
+    root: $env/opt


### PR DESCRIPTION
`opt/spack` follows the tree structure of the default Spack install tree, but we don't really need to follow it strictly, and we can save 6 characters from the shebang line.