### PR TITLE
[myriad] Set `LD_LIBRARY_PATH` for all GCC versions

### DIFF
--- a/benchmarks/spack/myriad/compute-node/spack.yaml
+++ b/benchmarks/spack/myriad/compute-node/spack.yaml
@@ -59,7 +59,9 @@ spack:
       operating_system: rhel7
       target: x86_64
       modules: []
-      environment: {}
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /shared/ucl/apps/gcc/4.9.2/lib64
       extra_rpaths: []
   - compiler:
       spec: gcc@7.3.0
@@ -72,7 +74,9 @@ spack:
       operating_system: rhel7
       target: x86_64
       modules: []
-      environment: {}
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /shared/ucl/apps/gcc/7.3.0/lib64
       extra_rpaths: []
   - compiler:
       spec: gcc@8.3.0
@@ -85,7 +89,9 @@ spack:
       operating_system: rhel7
       target: x86_64
       modules: []
-      environment: {}
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /shared/ucl/apps/gcc/8.3.0/lib64
       extra_rpaths: []
   - compiler:
       spec: gcc@9.2.0
@@ -98,7 +104,9 @@ spack:
       operating_system: rhel7
       target: x86_64
       modules: []
-      environment: {}
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /shared/ucl/apps/gcc/9.2.0/lib64
       extra_rpaths: []
   - compiler:
       spec: gcc@10.2.0


### PR DESCRIPTION
This makes it possible to run C++ programs, such as `cmake`, built with
compilers newer than the system default one.