### PR TITLE
[Tursa] Automatically set `--account` flag for scheduler

### DIFF
--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -137,16 +137,3 @@ reframe -c examples/sombrero -r --performance-report --system tesseract:compute-
 ```
 
 where `<ACCOUNT>` is the project you want to charge.
-
-## Tursa
-
-### Queue options
-
-When submitting jobs to compute nodes, you need to specify the job queue, with the `--account` option to the scheduler.
-To do this, when you run a benchmark you can use the `-J`/`--job-option` flag to `reframe` to specify the account, for example:
-
-```
-reframe -c examples/sombrero -r --performance-report --system tursa:compute-node -J'--accout=<ACCOUNT>'
-```
-
-where `<ACCOUNT>` is the project you want to charge.

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -1,4 +1,6 @@
 import os
+import reframe.utility.osext as osext
+
 
 # Some systems, notably some Cray-based ones, don't have access to the home filesystem.
 # This means that if you set up Spack in your bashrc script, this file won't be loaded and
@@ -272,7 +274,11 @@ site_configuration = {
                     'descr': 'CPU computing nodes',
                     'scheduler': 'slurm',
                     'launcher': 'mpirun',
-                    'access': ['--partition=cpu', '--qos=standard'],
+                    'access': [
+                        '--partition=cpu',
+                        '--qos=standard',
+                        f'--account={osext.osgroup()}',
+                    ],
                     'environs': ['default'],
                     'sched_options': {
                         'use_nodes_option': True,


### PR DESCRIPTION
On Tursa we can automatically set the `--account` flag, unfortunately on the other DiRac systems I could test `reframe.utility.osext.osgroup()` doesn't return what we need.