### PR TITLE
[reframe] Use new names of performance reference thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ create a very basic environment (see "Usage on unsupported systems" section belo
 
 [ReFrame](https://reframe-hpc.readthedocs.io/en/stable/) is a high-level
 framework for writing regression tests for HPC systems.  For our tests we
-require ReFrame v4.1.0.
+require ReFrame v4.1.3.
 
 If you need to manually install ReFrame, follow the [official
 instructions](https://reframe-hpc.readthedocs.io/en/stable/started.html) to

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -440,8 +440,8 @@ site_configuration = {
                         '%(check_perf_value)s|'
                         '%(check_perf_unit)s|'
                         '%(check_perf_ref)s|'
-                        '%(check_perf_lower)s|'
-                        '%(check_perf_upper)s|'
+                        '%(check_perf_lower_thres)s|'
+                        '%(check_perf_upper_thres)s|'
                     ),
                     'append': True
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "reframe-hpc >= 4.1.0, < 5.0.0",
+    "reframe-hpc >= 4.1.3, < 5.0.0",
     "matplotlib >= 3.0.0",
 ]
 


### PR DESCRIPTION
Names were uniformised in ReFrame v4.1.3.  These are the names that are now [documented](https://reframe-hpc.readthedocs.io/en/v4.1.3/config_reference.html#config.logging.handlers_perflog.format_perfvars).