### PR TITLE
[reframe] Add `extra_resources` attribute to the perflog

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -434,6 +434,7 @@ site_configuration = {
                         '%(check_num_tasks_per_node)s|'
                         '%(check_perfvalues)s|'
                         '%(check_spack_spec)s|'
+                        '%(check_extra_resources)s|'
                         '%(check_env_vars)s'
                     ),
                     'format_perfvars': (


### PR DESCRIPTION
We're already using `extra_resources` for the SGE scheduler, but we may expand its usage in the future, for example starting from #115 we may use it to set the number of GPU devices used, and could later use it for something more, so I think it may be useful to log also this attribute.