### PR TITLE
Add configuration for GPU nodes on Myriad and Tursa

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -115,6 +115,7 @@ site_configuration = {
                     'launcher': 'mpirun',
                     'environs': ['default'],
                     'max_jobs': 36,
+                    'features': ['gpu'],
                     'processor': {
                         'num_cpus': 36,
                         'num_cpus_per_core': 1,
@@ -124,11 +125,15 @@ site_configuration = {
                     'resources': [
                         {
                             'name': 'mpi',
-                            'options': ['-pe mpi {num_slots}']
+                            'options': ['-pe mpi {num_slots}'],
                         },
-                    ]
+                        {
+                            'name': 'gpu',
+                            'options': ['-l gpu={num_gpus_per_node}'],
+                        },
+                    ],
                 },
-            ]
+            ],
         },  # end Myriad
         {
             # https://gw4-isambard.github.io/docs/user-guide/MACS.html
@@ -268,12 +273,13 @@ site_configuration = {
             'hostnames': ['tursa-login.*'],
             'partitions': [
                 {
-                    'name': 'cpu',
-                    'descr': 'CPU computing nodes',
+                    'name': 'gpu',
+                    'descr': 'GPU computing nodes',
                     'scheduler': 'slurm',
                     'launcher': 'mpirun',
-                    'access': ['--partition=cpu', '--qos=standard'],
+                    'access': ['--partition=gpu', '--qos=standard'],
                     'environs': ['default'],
+                    'features': ['gpu'],
                     'sched_options': {
                         'use_nodes_option': True,
                     },
@@ -281,18 +287,15 @@ site_configuration = {
                     'processor': {
                         'num_cpus': 64,
                         'num_cpus_per_core': 2,
-                        'num_sockets': 2,
+                        'num_sockets': 1,
                         'num_cpus_per_socket': 32,
                     },
-                },
-                {
-                    'name': 'gpu',
-                    'descr': 'GPU computing nodes',
-                    'scheduler': 'slurm',
-                    'launcher': 'mpirun',
-                    'access': ['--partition=gpu', '--qos=standard'],
-                    'environs': ['default'],
-                    'max_jobs': 16,
+                    'resources': [
+                        {
+                            'name': 'gpu',
+                            'options': ['--gres=gpu:{num_gpus_per_node}']
+                        },
+                    ],
                 },
             ]
         },  # end Tursa
@@ -432,6 +435,7 @@ site_configuration = {
                         '%(check_num_tasks)s|'
                         '%(check_num_cpus_per_task)s|'
                         '%(check_num_tasks_per_node)s|'
+                        '%(check_num_gpus_per_node)s|'
                         '%(check_perfvalues)s|'
                         '%(check_spack_spec)s|'
                         '%(check_env_vars)s'

--- a/benchmarks/spack/common.yaml
+++ b/benchmarks/spack/common.yaml
@@ -1,6 +1,8 @@
 concretizer:
   unify: false
 packages:
+  cuda:
+    buildable: false
   mpi:
     buildable: false
 config:

--- a/benchmarks/spack/myriad/compute-node/spack.yaml
+++ b/benchmarks/spack/myriad/compute-node/spack.yaml
@@ -160,6 +160,18 @@ spack:
         prefix: /usr
     curl:
       externals:
+      - spec: cuda@7.5.18
+        prefix: /shared/ucl/apps/cuda/7.5.18/gnu-4.9.2
+      - spec: cuda@8.0.61
+        prefix: /shared/ucl/apps/cuda/8.0.61/gnu-4.9.2
+      - spec: cuda@9.0.176
+        prefix: /shared/ucl/apps/cuda/9.0.176/gnu-4.9.2
+      - spec: cuda@10.1.243
+        prefix: /shared/ucl/apps/cuda/10.1.243/gnu-4.9.2
+      - spec: cuda@10.1.243
+        prefix: /shared/ucl/apps/cuda/10.1.243/gnu-4.9.2
+    curl:
+      externals:
       - spec: curl@7.29.0+ldap
         prefix: /usr
     diffutils:

--- a/benchmarks/spack/tursa/gpu/spack.yaml
+++ b/benchmarks/spack/tursa/gpu/spack.yaml
@@ -27,17 +27,22 @@ spack:
       externals:
       - spec: autoconf@2.69
         prefix: /usr
-      buildable: false
     automake:
       externals:
       - spec: automake@1.16.1
         prefix: /usr
-      buildable: false
+    cuda:
+      externals:
+      - spec: cuda@11.0.2
+        prefix: /mnt/lustre/tursafs1/apps/cuda/11.0.2
+      - spec: cuda@11.0.3
+        prefix: /mnt/lustre/tursafs1/apps/cuda/11.0.3
+      - spec: cuda@11.4.1
+        prefix: /mnt/lustre/tursafs1/apps/cuda/11.4.1
     diffutils:
       externals:
       - spec: diffutils@3.6
         prefix: /usr
-      buildable: false
     gettext:
       externals:
       - spec: gettext@0.19.8.1
@@ -50,12 +55,10 @@ spack:
       externals:
       - spec: m4@1.4.18
         prefix: /usr
-      buildable: false
     ncurses:
       externals:
       - spec: ncurses@6.1.20180224+termlib abi=6
         prefix: /usr
-      buildable: false
     openmpi:
       externals:
       - spec: openmpi@4.1.1%gcc@9.3.0+cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
@@ -66,19 +69,15 @@ spack:
         prefix: /mnt/lustre/tursafs1/apps/basestack/cuda-11.0.2/openmpi/4.1.1
       - spec: openmpi@4.0.4%gcc@8.4.1+cuda~cxx~cxx_exceptions~java~memchecker~pmi~sqlite3~thread_multiple~wrapper-rpath
         prefix: /mnt/lustre/tursafs1/apps/openmpi/4.0.4
-      buildable: false
     perl:
       externals:
-      - spec: perl@5.26.3~cpanm+shared+threads
+      - spec: perl@5.26.3~cpanm~open+shared+threads
         prefix: /usr
-      buildable: false
     tar:
       externals:
       - spec: tar@1.30
         prefix: /usr
-      buildable: false
     xz:
       externals:
       - spec: xz@5.2.4
         prefix: /usr
-      buildable: false


### PR DESCRIPTION
Note: for simplicity, we're removing the CPU partition from Tursa, as most users will likely want to use the GPU partition on this machine.  We can later bring back the CPU partition if requested.

Taken out of #115.