### PR TITLE
[Isambard] Move `memory` to its own resource for Nvidia Ampere partition

### DIFF
--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -97,6 +97,12 @@ To run compilation on the compute node, you have to set the attribute [`build_lo
 reframe -c examples/sombrero -r --performance-report --system isambard-cascadelake:compute-node -S build_locally=false
 ```
 
+### Phase3 partition
+
+On the nodes with Nvidia Ampere GPUs, memory usage is restricted to 4 GiB by default.
+To request more memory you [have to specify the resource](https://gw4-isambard.github.io/docs/user-guide/PHASE3.html#nvidia-gpu) `mem=...G`, for example by setting the `memory` key of `extra_resources` to the amount of memory you require.
+This can be done on the command line of ReFrame [...]
+
 ## Myriad
 
 ### Python3 module

--- a/benchmarks/apps/cp2k/cp2k.py
+++ b/benchmarks/apps/cp2k/cp2k.py
@@ -27,9 +27,7 @@ class Cp2kBaseBenchmark(SpackTest):
         self.set_var_default('num_tasks_per_node',
                              self.current_partition.processor.num_cpus //
                              self.num_cpus_per_task)
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
         # For choosing the executable name, see for reference

--- a/benchmarks/apps/grid/grid.py
+++ b/benchmarks/apps/grid/grid.py
@@ -70,9 +70,7 @@ class GridBenchmark_ITT(GridBenchmark):
                              self.current_partition.processor.num_cpus //
                              self.num_cpus_per_task)
         self.executable_opts = [f'--mpi {self.mpi}', f'--shm {self.shm}', '--shm-hugetlb']
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks * self.num_cpus_per_task}
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
 

--- a/benchmarks/apps/hpgmg/hpgmg.py
+++ b/benchmarks/apps/hpgmg/hpgmg.py
@@ -31,9 +31,7 @@ class HpgmgTest(SpackTest):
     def setup_variables(self):
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}
 
     @run_before('compile')
     def setup_build_system(self):

--- a/benchmarks/apps/openmm/openmm_rfm.py
+++ b/benchmarks/apps/openmm/openmm_rfm.py
@@ -80,10 +80,8 @@ class OpenMMBenchmark(SpackTest):
             self.current_partition.processor.num_cpus)
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task},
-            'gpu': {'num_gpus_per_node': self.num_gpus_per_node},
-        }
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks * self.num_cpus_per_task}
+        self.extra_resources['gpu'] = {'num_gpus_per_node': self.num_gpus_per_node}
 
     # Download input files into the sources directory
     @run_after('setup')

--- a/benchmarks/apps/sombrero/sombrero.py
+++ b/benchmarks/apps/sombrero/sombrero.py
@@ -101,7 +101,7 @@ class SombreroBenchmarkMini(SombreroBenchmarkBase):
     def set_up_from_parameters(self):
         self.executable_opts = ['-l', '8x4x4x4', '-p', '2x1x1x1']
         self.num_tasks = 2
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}
 
 
 @rfm.simple_test
@@ -117,7 +117,7 @@ class SombreroBenchmarkScaling(SombreroBenchmarkBase):
             self.executable_opts.append('-w')
         self.executable_opts += ['-s', self.params[case_filter.Idx.size]]
         self.num_tasks = self.params[case_filter.Idx.nprocesses]
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}
 
 
 @rfm.simple_test
@@ -132,7 +132,7 @@ class SombreroITTsn(SombreroBenchmarkBase):
     @run_after('setup')
     def setup_num_tasks(self):
         self.num_tasks = self.current_partition.processor.num_cores
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}
 
 
 @rfm.simple_test
@@ -147,4 +147,4 @@ class SombreroITT64n(SombreroBenchmarkBase):
     @run_after('setup')
     def setup_num_tasks(self):
         self.num_tasks = self.current_partition.processor.num_cores * 64
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}

--- a/benchmarks/apps/swift/swift.py
+++ b/benchmarks/apps/swift/swift.py
@@ -41,9 +41,7 @@ class SwiftBenchmark(SpackTest):
     def setup_variables(self):
         self.executable_opts = ['--hydro', f'--threads={self.num_cpus_per_task}',
                                 'sodShock.yml']
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks * self.num_cpus_per_task}
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
 
     @run_before('compile')

--- a/benchmarks/apps/wrf/wrf.py
+++ b/benchmarks/apps/wrf/wrf.py
@@ -87,9 +87,7 @@ class WRFBaseBenchmark(SpackTest):
         self.set_var_default('num_tasks_per_node',
                              self.current_partition.processor.num_cpus //
                              self.num_cpus_per_task)
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks}
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
 

--- a/benchmarks/examples/sombrero/sombrero.py
+++ b/benchmarks/examples/sombrero/sombrero.py
@@ -50,10 +50,8 @@ class SombreroBenchmark(SpackTest):
     executable_opts = ['-w', '-s', 'small']
     # Time limit of the job, automatically set in the job script.
     time_limit = '2m'
-    # These extra resources are needed for when using the SGE scheduler.
-    extra_resources = {
-        'mpi': {'num_slots': num_tasks * num_cpus_per_task}
-    }
+    # The `mpi` extra resource is needed for when using the SGE scheduler.
+    extra_resources['mpi'] = {'num_slots': num_tasks * num_cpus_per_task}
     # Reference values for the performance benchmarks, see the
     # `set_perf_patterns` function below.
     reference = {

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -227,9 +227,12 @@ site_configuration = {
                     'resources': [
                         {
                             'name': 'gpu',
-                             # TODO: memory should be a separate resource.
-                            'options': ['ngpus={num_gpus_per_node}:mem=20G'],
+                            'options': ['ngpus={num_gpus_per_node}'],
                         },
+                        {
+                            'name': 'memory',
+                            'options': ['mem={memory}'],
+                        }
                     ],
                 },
             ]


### PR DESCRIPTION
Also, add items to `extra_resources` dictionary, instead of resetting it, which would override a setting on the command line.