### PR TITLE
Set `self.extra_resources` directly in base `SpackTest` class

### DIFF
--- a/benchmarks/apps/cp2k/cp2k.py
+++ b/benchmarks/apps/cp2k/cp2k.py
@@ -27,9 +27,6 @@ class Cp2kBaseBenchmark(SpackTest):
         self.set_var_default('num_tasks_per_node',
                              self.current_partition.processor.num_cpus //
                              self.num_cpus_per_task)
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
         # For choosing the executable name, see for reference

--- a/benchmarks/apps/grid/grid.py
+++ b/benchmarks/apps/grid/grid.py
@@ -69,9 +69,6 @@ class GridBenchmark_ITT(GridBenchmark):
                              self.current_partition.processor.num_cpus //
                              self.num_cpus_per_task)
         self.executable_opts = [f'--mpi {self.mpi}', f'--shm {self.shm}', '--shm-hugetlb']
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
 

--- a/benchmarks/apps/hpgmg/hpgmg.py
+++ b/benchmarks/apps/hpgmg/hpgmg.py
@@ -31,9 +31,6 @@ class HpgmgTest(SpackTest):
     def setup_variables(self):
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
 
     @run_before('sanity')
     def set_sanity_patterns(self):

--- a/benchmarks/apps/openmm/openmm_rfm.py
+++ b/benchmarks/apps/openmm/openmm_rfm.py
@@ -80,8 +80,6 @@ class OpenMMBenchmark(SpackTest):
             self.current_partition.processor.num_cpus)
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
-        # Needed for the SGE scheduler
-        self.extra_resources['mpi'] = {'num_slots': self.num_tasks * self.num_cpus_per_task}
         # Request the GPU resources necessary to run this job.
         self.extra_resources['gpu'] = {'num_gpus_per_node': self.num_gpus_per_node}
 

--- a/benchmarks/apps/sombrero/sombrero.py
+++ b/benchmarks/apps/sombrero/sombrero.py
@@ -96,7 +96,6 @@ class SombreroBenchmarkMini(SombreroBenchmarkBase):
     def set_up_from_parameters(self):
         self.executable_opts = ['-l', '8x4x4x4', '-p', '2x1x1x1']
         self.num_tasks = 2
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
 
 
 @rfm.simple_test
@@ -112,7 +111,6 @@ class SombreroBenchmarkScaling(SombreroBenchmarkBase):
             self.executable_opts.append('-w')
         self.executable_opts += ['-s', self.params[case_filter.Idx.size]]
         self.num_tasks = self.params[case_filter.Idx.nprocesses]
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
 
 
 @rfm.simple_test
@@ -127,7 +125,6 @@ class SombreroITTsn(SombreroBenchmarkBase):
     @run_after('setup')
     def setup_num_tasks(self):
         self.num_tasks = self.current_partition.processor.num_cores
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}
 
 
 @rfm.simple_test
@@ -142,4 +139,3 @@ class SombreroITT64n(SombreroBenchmarkBase):
     @run_after('setup')
     def setup_num_tasks(self):
         self.num_tasks = self.current_partition.processor.num_cores * 64
-        self.extra_resources = {'mpi': {'num_slots': self.num_tasks}}

--- a/benchmarks/apps/swift/swift.py
+++ b/benchmarks/apps/swift/swift.py
@@ -41,9 +41,6 @@ class SwiftBenchmark(SpackTest):
     def setup_variables(self):
         self.executable_opts = ['--hydro', f'--threads={self.num_cpus_per_task}',
                                 'sodShock.yml']
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
 
     @run_before('sanity')

--- a/benchmarks/apps/wrf/wrf.py
+++ b/benchmarks/apps/wrf/wrf.py
@@ -83,9 +83,6 @@ class WRFBaseBenchmark(SpackTest):
         self.set_var_default('num_tasks_per_node',
                              self.current_partition.processor.num_cpus //
                              self.num_cpus_per_task)
-        self.extra_resources = {
-            'mpi': {'num_slots': self.num_tasks * self.num_cpus_per_task}
-        }
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
 

--- a/benchmarks/examples/sombrero/sombrero.py
+++ b/benchmarks/examples/sombrero/sombrero.py
@@ -47,10 +47,6 @@ class SombreroBenchmark(SpackTest):
     executable_opts = ['-w', '-s', 'small']
     # Time limit of the job, automatically set in the job script.
     time_limit = '2m'
-    # These extra resources are needed for when using the SGE scheduler.
-    extra_resources = {
-        'mpi': {'num_slots': num_tasks * num_cpus_per_task}
-    }
     # Reference values for the performance benchmarks, see the
     # `set_perf_patterns` function below.
     reference = {

--- a/benchmarks/modules/utils.py
+++ b/benchmarks/modules/utils.py
@@ -270,7 +270,16 @@ class SpackTest(rfm.RegressionTest):
 
     @run_before('compile')
     def setup_build_system(self):
+        # The `self.spack_spec` attribute is the user-facing and loggable
+        # variable we use for setting the Spack spec, but then we need to
+        # forward its value to `self.build_system.specs`, which is the way to
+        # inform ReFrame which Spack specs to use.
         self.build_system.specs = [self.spack_spec]
+
+    @run_before('compile')
+    def set_sge_num_slots(self):
+        # Set the total number of CPUs to be requested for the SGE scheduler.
+        self.extra_resources['mpi']: {'num_slots': self.num_tasks * self.num_cpus_per_task}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the same vein as #137, further reduction of boilerplate code.

I need to double check this on Myriad, which is currently down, but I'm mostly confident this works as expected.