### PR TITLE
[config] Rename `generic` system to `default`

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -354,19 +354,18 @@ site_configuration = {
             ]
         },  # end DiaL3
         {
-            'name': 'generic',
-            'descr': 'generic',
+            'name': 'default',
+            'descr': 'Default system',
             'hostnames': ['.*'],
             'partitions': [
                 {
                     'name': 'default',
-                    'descr': 'Default system',
                     'scheduler': 'local',
                     'launcher': 'mpirun',
                     'environs': ['default'],
                 },
             ]
-        },  # end generic
+        },  # end default
         # < insert new systems here >
     ],
     'environments': [


### PR DESCRIPTION
This avoids conflicts with the builtin `generic` system.  Fix #140.