### PR TITLE
Add Nvidia Pascal GPU partition on Isambard

### DIFF
--- a/benchmarks/apps/openmm/openmm_rfm.py
+++ b/benchmarks/apps/openmm/openmm_rfm.py
@@ -51,6 +51,9 @@ class OpenMMBenchmark(SpackTest):
     num_gpus_per_node = 1
 
     reference = {
+        'isambard-macs:pascal': {
+            'speed': (3.6, -0.2, None, 'ns/day'),
+        },
         'isambard-macs:volta': {
             'speed': (6.5, -0.2, None, 'ns/day'),
         },

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -183,6 +183,28 @@ site_configuration = {
                     },
                 },
                 {
+                    'name': 'pascal',
+                    'descr': 'Broadwell computing nodes with Nvidia Pascal GPUs',
+                    'scheduler': 'pbs',
+                    'launcher': 'mpirun',
+                    'access': ['-q pascalq'],
+                    'environs': ['default'],
+                    'max_jobs': 20,
+                    'features': ['gpu'],
+                    'processor': {
+                        'num_cpus': 36,
+                        'num_cpus_per_core': 1,
+                        'num_sockets': 2,
+                        'num_cpus_per_socket': 18,
+                    },
+                    'resources': [
+                        {
+                            'name': 'gpu',
+                            'options': ['ngpus={num_gpus_per_node}'],
+                        },
+                    ],
+                },
+                {
                     'name': 'volta',
                     'descr': 'Cascadelake computing nodes with Nvidia Volta GPUs',
                     'scheduler': 'pbs',
@@ -205,7 +227,7 @@ site_configuration = {
                     ],
                 },
             ]
-        },  # end Isambard Cascadelake
+        },  # end Isambard MACS
         {
             # https://gw4-isambard.github.io/docs/user-guide/A64FX.html
             'name': 'isambard-a64fx',

--- a/benchmarks/spack/isambard-macs/pascal/spack.yaml
+++ b/benchmarks/spack/isambard-macs/pascal/spack.yaml
@@ -1,0 +1,23 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs: []
+  view: false
+  include:
+  - ../../common.yaml
+  - ../compilers.yaml
+  - ../packages.yaml
+  packages:
+    all:
+      require: 'target=broadwell'
+    cuda:
+      externals:
+      - spec: cuda@10.2.89
+        prefix: /cm/shared/apps/cuda10.2/toolkit/10.2.89
+      - spec: cuda@11.1.1
+        prefix: /cm/shared/apps/cuda11.1/toolkit/11.1.1
+      - spec: cuda@11.2.0
+        prefix: /cm/shared/apps/cuda11.2/toolkit/11.2.0


### PR DESCRIPTION
Ref #78.

```console
$ reframe -c benchmarks/apps/openmm/ -r --performance-report --system isambard-macs:pascal -S spack_spec='openmm +cuda ^openblas ^openmpi'
[ReFrame Setup]
  version:           4.1.3
  command:           '/lustre/home/ri-mgiordano/repo/excalibur-tests/excal-macs/bin/reframe -c benchmarks/apps/openmm/ -r --performance-report --system isambard-macs:pascal -S spack_spec=openmm +cuda ^openblas
^openmpi'
  launched by:       ri-mgiordano@login-01
  working directory: '/lustre/home/ri-mgiordano/repo/excalibur-tests'
  settings files:    '<builtin>', '/home/ri-mgiordano/repo/excalibur-tests/benchmarks/reframe_config.py'
  check search path: '/lustre/home/ri-mgiordano/repo/excalibur-tests/benchmarks/apps/openmm'
  stage directory:   '/lustre/home/ri-mgiordano/repo/excalibur-tests/stage'
  output directory:  '/lustre/home/ri-mgiordano/repo/excalibur-tests/output'
  log files:         '/tmp/rfm-9o7151y4.log'

[==========] Running 1 check(s)
[==========] Started on Wed May 10 09:24:36 2023

[----------] start processing checks
[ RUN      ] OpenMMBenchmark /1e2d99a2 @isambard-macs:pascal+default
[       OK ] (1/1) OpenMMBenchmark /1e2d99a2 @isambard-macs:pascal+default
P: speed: 3.64 ns/day (r:1, l:None, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
[==========] Finished on Wed May 10 10:11:36 2023

==================================================================================================================================================================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[OpenMMBenchmark /1e2d99a2 @isambard-macs:pascal:default]
  num_tasks: 1
  num_gpus_per_node: 1
  num_tasks_per_node: 1
  num_cpus_per_task: 36
  performance:
    - speed: 3.64 ns/day (r: 1 ns/day l: -inf% u: +inf%)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```