### PR TITLE
Add KNL partition on Isambard

### DIFF
--- a/benchmarks/apps/grid/grid.py
+++ b/benchmarks/apps/grid/grid.py
@@ -47,6 +47,9 @@ class GridBenchmark_ITT(GridBenchmark):
         'dial3': {
             'Performance': (28000, None, None, 'Mflop/s per node')
         },
+        'isambard-macs:knl': {
+            'Performance': (6500, None, None, 'Mflop/s per node')
+        },
         'myriad': {
             'Performance': (350000, None, None, 'Mflop/s per node')
         },

--- a/benchmarks/examples/sombrero/sombrero.py
+++ b/benchmarks/examples/sombrero/sombrero.py
@@ -86,6 +86,9 @@ class SombreroBenchmark(SpackTest):
         'isambard-macs:cascadelake': {
             'flops': (1.5, -0.2, None, 'Gflops/seconds'),
         },
+        'isambard-macs:knlcascadelake': {
+            'flops': (0.15, -0.2, None, 'Gflops/seconds'),
+        },
         'isambard-macs:rome': {
             'flops': (1.2, -0.2, None, 'Gflops/seconds'),
         },

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -154,7 +154,7 @@ site_configuration = {
             'partitions': [
                 {
                     'name': 'cascadelake',
-                    'descr': 'Intel Xeon Gold 6230 Cascade Lake Cascadelake computing nodes',
+                    'descr': 'Intel Xeon Gold 6230 Cascade Lake computing nodes',
                     'scheduler': 'pbs',
                     'launcher': 'mpirun',
                     'access': ['-q clxq'],
@@ -165,6 +165,21 @@ site_configuration = {
                         'num_cpus_per_core': 1,
                         'num_sockets': 2,
                         'num_cpus_per_socket': 20,
+                    },
+                },
+                {
+                    'name': 'knl',
+                    'descr': 'Intel Xeon Phi “Knights Landing” 7210 computing nodes',
+                    'scheduler': 'pbs',
+                    'launcher': 'mpirun',
+                    'access': ['-q knlq'],
+                    'environs': ['default'],
+                    'max_jobs': 20,
+                    'processor': {
+                        'num_cpus': 64,
+                        'num_cpus_per_core': 1,
+                        'num_sockets': 1,
+                        'num_cpus_per_socket': 64,
                     },
                 },
                 {

--- a/benchmarks/spack/isambard-macs/knl/spack.yaml
+++ b/benchmarks/spack/isambard-macs/knl/spack.yaml
@@ -1,0 +1,15 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs: []
+  view: false
+  include:
+  - ../../common.yaml
+  - ../compilers.yaml
+  - ../packages.yaml
+  packages:
+    all:
+      require: 'target=mic_knl'


### PR DESCRIPTION
Ref #78

```console
$ reframe -c benchmarks/examples/sombrero -r --performance-report --system isambard-macs:knl -S spack_spec='sombrero@2021-08-16 ^openmpi' -S build_locally=false
[ReFrame Setup]
  version:           4.1.3
  command:           '/lustre/home/ri-mgiordano/repo/excalibur-tests/excal-macs/bin/reframe -c benchmarks/examples/sombrero -r --performance-report --system isambard-macs:knl -S spack_spec=sombrero@2021-08-16 ^openmpi -S build_locally=false'
  launched by:       ri-mgiordano@login-01
  working directory: '/lustre/home/ri-mgiordano/repo/excalibur-tests'
  settings files:    '<builtin>', '/home/ri-mgiordano/repo/excalibur-tests/benchmarks/reframe_config.py'
  check search path: '/lustre/home/ri-mgiordano/repo/excalibur-tests/benchmarks/examples/sombrero'
  stage directory:   '/lustre/home/ri-mgiordano/repo/excalibur-tests/stage'
  output directory:  '/lustre/home/ri-mgiordano/repo/excalibur-tests/output'
  log files:         '/tmp/rfm-71vjbh99.log'

[==========] Running 1 check(s)
[==========] Started on Wed May 10 10:22:26 2023

[----------] start processing checks
[ RUN      ] SombreroBenchmark /cc391b86 @isambard-macs:knl+default
[       OK ] (1/1) SombreroBenchmark /cc391b86 @isambard-macs:knl+default
P: flops: 0.16 Gflops/seconds (r:1, l:None, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
[==========] Finished on Wed May 10 10:31:20 2023

==================================================================================================================================================================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[SombreroBenchmark /cc391b86 @isambard-macs:knl:default]
  num_cpus_per_task: 1
  num_tasks_per_node: 1
  num_tasks: 1
  performance:
    - flops: 0.16 Gflops/seconds (r: 1 Gflops/seconds l: -inf% u: +inf%)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


$ reframe -c benchmarks/apps/grid -r --performance-report --system isambard-macs:knl -S build_locally=false --setvar=mpi='1.1.1.1' --setvar=num_cpus_per_task=64 --setvar=shm=4096 -S time_limit='6h'
[ReFrame Setup]
  version:           4.1.3
  command:           '/lustre/home/ri-mgiordano/repo/excalibur-tests/excal-macs/bin/reframe -c benchmarks/apps/grid -r --performance-report --system isambard-macs:knl -S build_locally=false --setvar=mpi=1.1.1.1 --setvar=num_cpus_per_task=64 --setvar=shm=4096 -S time_limit=6h'
  launched by:       ri-mgiordano@login-01
  working directory: '/lustre/home/ri-mgiordano/repo/excalibur-tests'
  settings files:    '<builtin>', '/home/ri-mgiordano/repo/excalibur-tests/benchmarks/reframe_config.py'
  check search path: '/lustre/home/ri-mgiordano/repo/excalibur-tests/benchmarks/apps/grid'
  stage directory:   '/lustre/home/ri-mgiordano/repo/excalibur-tests/stage'
  output directory:  '/lustre/home/ri-mgiordano/repo/excalibur-tests/output'
  log files:         '/tmp/rfm-k0uwm401.log'

[==========] Running 1 check(s)
[==========] Started on Wed May 10 10:40:52 2023

[----------] start processing checks
[ RUN      ] GridBenchmark_ITT /104caaeb @isambard-macs:knl+default
[       OK ] (1/1) GridBenchmark_ITT /104caaeb @isambard-macs:knl+default
P: Performance: 6761.507 Mflop/s per node (r:150000, l:None, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
[==========] Finished on Wed May 10 14:00:33 2023

==================================================================================================================================================================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[GridBenchmark_ITT /104caaeb @isambard-macs:knl:default]
  num_tasks: 1
  num_cpus_per_task: 64
  num_tasks_per_node: 1
  performance:
    - Performance: 6761.507 Mflop/s per node (r: 150000 Mflop/s per node l: -inf% u: +inf%)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```