### PR TITLE
Add Milan CPU partition on Isambard Phase 3

### DIFF
--- a/benchmarks/examples/sombrero/sombrero.py
+++ b/benchmarks/examples/sombrero/sombrero.py
@@ -88,6 +88,9 @@ class SombreroBenchmark(SpackTest):
         'isambard-macs:rome': {
             'flops': (1.2, -0.2, None, 'Gflops/seconds'),
         },
+        'isambard-p3:milan': {
+            'flops': (1.5, -0.2, None, 'Gflops/seconds'),
+        },
         'isambard-xci': {
             'flops': (0.6, -0.2, None, 'Gflops/seconds'),
         },

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -271,6 +271,7 @@ site_configuration = {
             'name': 'isambard-phase3',
             'descr': 'Isambard 2 Phase 3 system',
             'hostnames': ['p3-login'],
+            'modules_system': 'lmod',
             'partitions': [
                 {
                     'name': 'ampere',
@@ -309,6 +310,22 @@ site_configuration = {
                         'num_cpus_per_core': 2,
                         'num_sockets': 1,
                         'num_cpus_per_socket': 32,
+                    }
+                },
+                {
+                    'name': 'milan',
+                    'descr': 'AMD EPYC 7713 64-Core Processor "Milan" compute nodes',
+                    'scheduler': 'pbs',
+                    'launcher': 'mpiexec',
+                    'modules': ['cray-pals'],
+                    'access': ['-q milanq'],
+                    'environs': ['default'],
+                    'max_jobs': 20,
+                    'processor': {
+                        'num_cpus': 256,
+                        'num_cpus_per_core': 2,
+                        'num_sockets': 2,
+                        'num_cpus_per_socket': 64,
                     },
                 },
             ]

--- a/benchmarks/spack/isambard-phase3/compilers.yaml
+++ b/benchmarks/spack/isambard-phase3/compilers.yaml
@@ -48,7 +48,8 @@ compilers:
     flags: {}
     operating_system: rhel8
     target: x86_64
-    modules: []
+    modules:
+    - gcc/10.3.0
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -61,6 +62,7 @@ compilers:
     flags: {}
     operating_system: rhel8
     target: x86_64
-    modules: []
+    modules:
+    - gcc/11.2.0
     environment: {}
     extra_rpaths: []

--- a/benchmarks/spack/isambard-phase3/compilers.yaml
+++ b/benchmarks/spack/isambard-phase3/compilers.yaml
@@ -66,3 +66,42 @@ compilers:
     - gcc/11.2.0
     environment: {}
     extra_rpaths: []
+- compiler:
+    spec: dpcpp@2021.4.0
+    paths:
+      cc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/icx
+      cxx: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/dpcpp
+      f77: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/ifx
+      fc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@2021.4.0
+    paths:
+      cc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/intel64/icc
+      cxx: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/intel64/icpc
+      f77: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/intel64/ifort
+      fc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2021.4.0
+    paths:
+      cc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/icx
+      cxx: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/icpx
+      f77: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/ifx
+      fc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/benchmarks/spack/isambard-phase3/milan/spack.yaml
+++ b/benchmarks/spack/isambard-phase3/milan/spack.yaml
@@ -1,0 +1,12 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs: []
+  view: false
+  include:
+  - ../../common.yaml
+  - ../compilers.yaml
+  - ../packages.yaml

--- a/benchmarks/spack/isambard-phase3/packages.yaml
+++ b/benchmarks/spack/isambard-phase3/packages.yaml
@@ -11,10 +11,13 @@ packages:
     externals:
     - spec: cmake@3.11.4
       prefix: /usr
-  # cray-mpich:
-  #   externals:
-  #   - spec: cray-mpich@8.1.0%gcc
-  #     prefix: /opt/cray/pe/mpich/8.1.11/ofi/gnu/9.1
+  cray-mpich:
+    externals:
+    - spec: cray-mpich@8.1.11%gcc +wrappers
+      prefix: /opt/cray/pe/mpich/8.1.11/ofi/gnu/9.1
+      modules:
+      - libfabric/1.11.0.4.95
+      - cray-mpich/8.1.11
   diffutils:
     externals:
     - spec: diffutils@3.6
@@ -31,6 +34,10 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  libfabric:
+    externals:
+    - spec: libfabric@1.11.0 fabrics=sockets,verbs
+      prefix: /opt/cray/libfabric/1.11.0.4.95
   libtool:
     externals:
     - spec: libtool@2.4.6
@@ -53,12 +60,12 @@ packages:
       prefix: /usr
   python:
     externals:
-    - spec: python@3.9.4+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
-      prefix: /lustre/home/ri-mgiordano/repo/excalibur-tests/excal-p3
     - spec: python@2.7.17+bz2+crypt+ctypes+dbm~lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib
       prefix: /usr
     - spec: python@3.6.8+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib
       prefix: /usr
+    - spec: python@3.9.4+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib
+      prefix: /opt/cray/pe/python/3.9.4.2
   tar:
     externals:
     - spec: tar@1.30

--- a/benchmarks/spack/isambard-phase3/packages.yaml
+++ b/benchmarks/spack/isambard-phase3/packages.yaml
@@ -34,6 +34,12 @@ packages:
     externals:
     - spec: gmake@4.2.1
       prefix: /usr
+  intel-oneapi-mpi:
+    externals:
+    - spec: intel-oneapi-mpi@2021.4.0 +generic-names
+      prefix: /lustre/software/x86/tools/oneapi-2021.4.0
+      modules:
+      - IntelOneApi/mpi/2021.4.0
   libfabric:
     externals:
     - spec: libfabric@1.11.0 fabrics=sockets,verbs


### PR DESCRIPTION
Ref #78.

~Opening as draft as I still haven't figured out how to make compilation of MPI programs work properly.~

```console
$ reframe -c benchmarks/examples/sombrero -r --performance-report --system isambard-phase3:milan
[ReFrame Setup]
  version:           4.1.3
  command:           '/lustre/home/ri-mgiordano/repo/excalibur-tests/excal-p3/bin/reframe -c benchmarks/examples/sombrero -r --performance-report --system isambard-phase3:milan'
  launched by:       ri-mgiordano@p3-login
  working directory: '/lustre/home/ri-mgiordano/repo/excalibur-tests'
  settings files:    '<builtin>', '/lustre/home/ri-mgiordano/repo/excalibur-tests/benchmarks/reframe_config.py'
  check search path: '/lustre/home/ri-mgiordano/repo/excalibur-tests/benchmarks/examples/sombrero'
  stage directory:   '/lustre/home/ri-mgiordano/repo/excalibur-tests/stage'
  output directory:  '/lustre/home/ri-mgiordano/repo/excalibur-tests/output'
  log files:         '/tmp/rfm-xpfd3hby.log'

[==========] Running 1 check(s)
[==========] Started on Thu May 11 14:30:09 2023

[----------] start processing checks
[ RUN      ] SombreroBenchmark /cc391b86 @isambard-phase3:milan+default
[       OK ] (1/1) SombreroBenchmark /cc391b86 @isambard-phase3:milan+default
P: flops: 1.45 Gflops/seconds (r:1, l:None, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
[==========] Finished on Thu May 11 14:30:33 2023

==================================================================================================================================================================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[SombreroBenchmark /cc391b86 @isambard-phase3:milan:default]
  num_tasks: 1
  num_tasks_per_node: 1
  num_cpus_per_task: 1
  performance:
    - flops: 1.45 Gflops/seconds (r: 1 Gflops/seconds l: -inf% u: +inf%)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```