### PR TITLE
Remove unused programming environments

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -102,7 +102,7 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'launcher': 'mpirun',
                     'access': ['--partition=icelake'],
-                    'environs': ['default', 'intel2020-csd3'],
+                    'environs': ['default'],
                     'max_jobs': 64,
                     'processor': {
                         'num_cpus': 76,
@@ -391,7 +391,7 @@ site_configuration = {
                     'scheduler': 'slurm',
                     'launcher': 'mpiexec',
                     'access': ['--partition=cosma8'],
-                    'environs': ['default', 'intel20-mpi-durham', 'intel20_u2-mpi-durham', 'intel19-mpi-durham', 'intel19_u3-mpi-durham'],
+                    'environs': ['default'],
                     'sched_options': {
                         'use_nodes_option': True,
                     },
@@ -463,7 +463,7 @@ site_configuration = {
                     'descr': 'Computing nodes',
                     'scheduler': 'slurm',
                     'launcher': 'mpirun',
-                    'environs': ['default', 'intel-oneapi-openmpi-dial3','intel19-mpi-dial3'],
+                    'environs': ['default'],
                     'max_jobs': 64,
                     'processor': {
                         'num_cpus': 128,
@@ -498,62 +498,6 @@ site_configuration = {
             'cc': 'cc',
             'cxx': 'c++',
             'ftn': 'ftn'
-        },
-        {
-            'name': 'intel20-mpi-durham',
-            'modules':['intel_comp/2020','intel_mpi/2020'],
-            'cc': 'mpiicc',
-            'cxx': 'mpiicpc',
-            'ftn': 'mpiifort'
-        },
-        {
-            'name': 'intel20_u2-mpi-durham',
-            'modules':['intel_comp/2020-update2','intel_mpi/2020-update2'],
-            'cc': 'mpiicc',
-            'cxx': 'mpiicpc',
-            'ftn': 'mpiifort'
-        },
-        {
-            'name': 'intel19-mpi-durham',
-            'modules':['intel_comp/2019','intel_mpi/2019'],
-            'cc': 'mpiicc',
-            'cxx': 'mpiicpc',
-            'ftn': 'mpiifort'
-        },
-        {
-            'name': 'intel19_u3-mpi-durham',
-            'modules':['intel_comp/2019-update3','intel_mpi/2019-update3'],
-            'cc': 'mpiicc',
-            'cxx': 'mpiicpc',
-            'ftn': 'mpiifort'
-        },
-        {
-            'name':'intel-oneapi-openmpi-dial3',
-            'modules':['intel-oneapi-compilers/2021.2.0','openmpi4/intel/4.0.5'],
-            'cc':'mpicc',
-            'cxx':'mpicxx',
-            'ftn':'mpif90'
-        },
-        {
-            'name': 'intel19-mpi-dial3',
-            'modules':['intel-parallel-studio/cluster.2019.5'],
-            'cc': 'mpiicc',
-            'cxx': 'mpiicpc',
-            'ftn': 'mpiifort'
-        },
-        {
-            'name': 'intel2020-csd3',
-            'modules': ["intel/compilers/2020.4",
-                        "intel/mkl/2020.4",
-                        "intel/impi/2020.4/intel",
-                        "intel/libs/idb/2020.4",
-                        "intel/libs/tbb/2020.4",
-                        "intel/libs/ipp/2020.4",
-                        "intel/libs/daal/2020.4",
-                        "intel/bundles/complib/2020.4"],
-            'cc': 'mpiicc',
-            'cxx': 'mpiicpc',
-            'ftn': 'mpiifort'
         },
     ],
     'logging': [


### PR DESCRIPTION
We don't use programming environments in ReFrame, the choice of compiler is made by spack and controlled by te spack spec. The available compilers on each system are recorded in their spack environments. Setting them in ReFrame does nothing, because spack will not pay attention to the ReFrame programming environment