### PR TITLE
Add `cuda` feature to config of systems with Nvidia GPUs

### DIFF
--- a/benchmarks/apps/openmm/openmm_rfm.py
+++ b/benchmarks/apps/openmm/openmm_rfm.py
@@ -33,8 +33,8 @@ def download(url, match, dest):
 
 @rfm.simple_test
 class OpenMMBenchmark(SpackTest):
-    # This can be run only on GPU-equipped systems.
-    valid_systems = ['+gpu']
+    # This can be run only on systems with Nvidia GPUs.
+    valid_systems = ['+gpu +cuda']
     valid_prog_environs = ['default']
     spack_spec = 'openmm@7.7.0 +cuda'
 

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -126,7 +126,7 @@ site_configuration = {
                     'launcher': 'mpirun',
                     'environs': ['default'],
                     'max_jobs': 36,
-                    'features': ['gpu'],
+                    'features': ['gpu', 'cuda'],
                     'processor': {
                         'num_cpus': 36,
                         'num_cpus_per_core': 1,
@@ -205,7 +205,7 @@ site_configuration = {
                     'access': ['-q pascalq'],
                     'environs': ['default'],
                     'max_jobs': 20,
-                    'features': ['gpu'],
+                    'features': ['gpu', 'cuda'],
                     'processor': {
                         'num_cpus': 36,
                         'num_cpus_per_core': 1,
@@ -227,7 +227,7 @@ site_configuration = {
                     'access': ['-q voltaq'],
                     'environs': ['default'],
                     'max_jobs': 20,
-                    'features': ['gpu'],
+                    'features': ['gpu', 'cuda'],
                     'processor': {
                         'num_cpus': 40,
                         'num_cpus_per_core': 1,
@@ -280,7 +280,7 @@ site_configuration = {
                     'access': ['-q ampereq'],
                     'environs': ['default'],
                     'max_jobs': 20,
-                    'features': ['gpu'],
+                    'features': ['gpu', 'cuda'],
                     'processor': {
                         'num_cpus': 64,
                         'num_cpus_per_core': 2,
@@ -431,7 +431,7 @@ site_configuration = {
                     'launcher': 'mpirun',
                     'access': ['--partition=gpu', '--qos=standard'],
                     'environs': ['default'],
-                    'features': ['gpu'],
+                    'features': ['gpu', 'cuda'],
                     'sched_options': {
                         'use_nodes_option': True,
                     },


### PR DESCRIPTION
This lets us distinguish systems with Nvidia GPUs from those with AMD GPUs.

CC: @kaanolgu.