### PR TITLE
[cosma8] Fix oneAPI compiler settings in Spack environment

### DIFF
--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -360,6 +360,19 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
+      spec: intel@2021.7.1
+      paths:
+        cc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/intel64/icc
+        cxx: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/intel64/icpc
+        f77: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/intel64/ifort
+        fc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/intel64/ifort
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
       spec: oneapi@2021.1
       paths:
         cc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icx
@@ -391,6 +404,45 @@ spack:
           LD_LIBRARY_PATH: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
       extra_rpaths:
       - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
+  - compiler:
+      spec: oneapi@2022.2.1
+      paths:
+        cc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/icx
+        cxx: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/icpx
+        f77: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
+        fc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: dpcpp@2021.3.0
+      paths:
+        cc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/icx
+        cxx: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/dpcpp
+        f77: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
+        fc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: dpcpp@2022.2.1
+      paths:
+        cc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/icx
+        cxx: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/dpcpp
+        f77: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
+        fc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
   packages:
     autoconf:
       externals:
@@ -526,6 +578,8 @@ spack:
         prefix: /cosma/local/intel/oneAPI_2021.1.0
       - spec: intel-oneapi-mpi@2021.3.0+generic-names%oneapi@2021.3.0
         prefix: /cosma/local/intel/oneAPI_2021.3.0
+      - spec: intel-oneapi-mpi@2021.7.1+generic-names%oneapi@2022.2.1
+        prefix: /cosma/local/intel/oneAPI_2022.3.0
     libfuse:
       externals:
       - spec: libfuse@2.9.2

--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -620,22 +620,22 @@ spack:
       - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%intel
           schedulers=slurm
         prefix: /cosma/local/openmpi/intel_2018/3.0.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@11.1.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_11.1.0/4.1.1.no-ucx
-      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
+      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@10.2.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_10.2.0/3.0.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
           fabrics=ucx schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_9.3.0/4.1.1
-      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
+      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_9.3.0/4.0.3
-      - spec: openmpi@4.1.0a1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc
+      - spec: openmpi@4.1.0a1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
           fabrics=ucx schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_7.3.0/20190429
-      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc
+      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_7.3.0/3.0.1
       - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%aocc@2.2.0

--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -347,19 +347,6 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: oneapi@2021.1
-      paths:
-        cc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icx
-        cxx: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icpx
-        f77: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
-        fc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
-      flags: {}
-      operating_system: centos7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
       spec: intel@2021.3.0
       paths:
         cc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/intel64/icc
@@ -373,6 +360,22 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
+      spec: oneapi@2021.1
+      paths:
+        cc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icx
+        cxx: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icpx
+        f77: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
+        fc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/compiler/lib/intel64_lin
+      extra_rpaths:
+      - /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/compiler/lib/intel64_lin
+  - compiler:
       spec: oneapi@2021.3.0
       paths:
         cc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/icx
@@ -383,8 +386,11 @@ spack:
       operating_system: centos7
       target: x86_64
       modules: []
-      environment: {}
-      extra_rpaths: []
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
+      extra_rpaths:
+      - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
   packages:
     autoconf:
       externals:
@@ -494,26 +500,32 @@ spack:
         prefix: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.2.254/linux/mkl
     intel-mpi:
       externals:
-      - spec: intel-mpi@2017.1.132
+      - spec: intel-mpi@2017.1.132%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2017-update1
-      - spec: intel-mpi@2017.2.174
+      - spec: intel-mpi@2017.2.174%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2017-update1
-      - spec: intel-mpi@2018.2.199
+      - spec: intel-mpi@2018.2.199%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2018
-      - spec: intel-mpi@2019.1.144
+      - spec: intel-mpi@2019.1.144%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2019
-      - spec: intel-mpi@2019.2.187
+      - spec: intel-mpi@2019.2.187%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2019
-      - spec: intel-mpi@2019.3.199
+      - spec: intel-mpi@2019.3.199%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2019
-      - spec: intel-mpi@2019.4.243
+      - spec: intel-mpi@2019.4.243%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2019
-      - spec: intel-mpi@2020.0.166
+      - spec: intel-mpi@2020.0.166%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2020
-      - spec: intel-mpi@2020.1.217
+      - spec: intel-mpi@2020.1.217%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2020
-      - spec: intel-mpi@2020.2.254
+      - spec: intel-mpi@2020.2.254%intel
         prefix: /cosma/local/intel/Parallel_Studio_XE_2020
+    intel-oneapi-mpi:
+      externals:
+      - spec: intel-oneapi-mpi@2021.1.1+generic-names%oneapi@2021.1
+        prefix: /cosma/local/intel/oneAPI_2021.1.0
+      - spec: intel-oneapi-mpi@2021.3.0+generic-names%oneapi@2021.3.0
+        prefix: /cosma/local/intel/oneAPI_2021.3.0
     libfuse:
       externals:
       - spec: libfuse@2.9.2
@@ -551,34 +563,34 @@ spack:
         prefix: /usr
     openmpi:
       externals:
-      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%intel
           schedulers=slurm
         prefix: /cosma/local/openmpi/intel_2018/3.0.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_11.1.0/4.1.1.no-ucx
-      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_10.2.0/3.0.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
           fabrics=ucx schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_9.3.0/4.1.1
-      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_9.3.0/4.0.3
-      - spec: openmpi@4.1.0a1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.1.0a1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc
           fabrics=ucx schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_7.3.0/20190429
-      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_7.3.0/3.0.1
-      - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%aocc@2.2.0
           fabrics=ucx schedulers=slurm
         prefix: /cosma/local/openmpi/aocc_2.2.0/4.0.5
-      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@2.0.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/aocc_2.0.0/4.0.1
-      - spec: openmpi@4.0.1%aocc@1.3.0~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@1.3.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/aocc_1.3.0/4.0.1
     openssh:

--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -620,33 +620,33 @@ spack:
       - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%intel
           schedulers=slurm
         prefix: /cosma/local/openmpi/intel_2018/3.0.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@11.1.0
-          schedulers=slurm
-        prefix: /cosma/local/openmpi/gnu_11.1.0/4.1.1.no-ucx
-      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@10.2.0
-          schedulers=slurm
-        prefix: /cosma/local/openmpi/gnu_10.2.0/3.0.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
-          fabrics=ucx schedulers=slurm
-        prefix: /cosma/local/openmpi/gnu_9.3.0/4.1.1
-      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
-          schedulers=slurm
-        prefix: /cosma/local/openmpi/gnu_9.3.0/4.0.3
-      - spec: openmpi@4.1.0a1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
-          fabrics=ucx schedulers=slurm
-        prefix: /cosma/local/openmpi/gnu_7.3.0/20190429
       - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/gnu_7.3.0/3.0.1
-      - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%aocc@2.2.0
-          fabrics=ucx schedulers=slurm
-        prefix: /cosma/local/openmpi/aocc_2.2.0/4.0.5
-      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@2.0.0
+      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@10.2.0
           schedulers=slurm
-        prefix: /cosma/local/openmpi/aocc_2.0.0/4.0.1
+        prefix: /cosma/local/openmpi/gnu_10.2.0/3.0.1
       - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@1.3.0
           schedulers=slurm
         prefix: /cosma/local/openmpi/aocc_1.3.0/4.0.1
+      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@2.0.0
+          schedulers=slurm
+        prefix: /cosma/local/openmpi/aocc_2.0.0/4.0.1
+      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
+          schedulers=slurm
+        prefix: /cosma/local/openmpi/gnu_9.3.0/4.0.3
+      - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%aocc@2.2.0
+          fabrics=ucx schedulers=slurm
+        prefix: /cosma/local/openmpi/aocc_2.2.0/4.0.5
+      - spec: openmpi@4.1.0a1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
+          fabrics=ucx schedulers=slurm
+        prefix: /cosma/local/openmpi/gnu_7.3.0/20190429
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
+          fabrics=ucx schedulers=slurm
+        prefix: /cosma/local/openmpi/gnu_9.3.0/4.1.1
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@11.1.0
+          schedulers=slurm
+        prefix: /cosma/local/openmpi/gnu_11.1.0/4.1.1.no-ucx
     openssh:
       externals:
       - spec: openssh@7.4p1

--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -370,8 +370,11 @@ spack:
       operating_system: centos7
       target: x86_64
       modules: []
-      environment: {}
-      extra_rpaths: []
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/compiler/lib/intel64_lin
+      extra_rpaths:
+      - /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/compiler/lib/intel64_lin
   - compiler:
       spec: oneapi@2021.1
       paths:


### PR DESCRIPTION
The main problem was that the compiler itself links to `libimf.so` (Intel Math Library) and relies on `LD_LIBRARY_PATH` being set correctly for the dynamic loader to find it at runtime.  Likewise, the compiler generates binaries which link to `libimf.so` without setting rpath/runpath, and so `LD_LIBRARY_PATH` would be needed again to use those binaries.

The solution was to update the compiler settings in the spack environment to add the directory where `libimf.so` is to `LD_LIBRARY_PATH`, to make the compiler work in the first place, _and_ to list the same directory as an additional rpath to set when linking objects with oneAPI toolchains.

Fix #155.  ~I can't currently run benchmarks with reframe, but~ building of `sombrero%oneapi@2021.1` and `sombrero%oneapi@2021.3.0` worked successfully 


```console
$ reframe -c benchmarks/examples/sombrero/ -r --performance-report --system cosma8 -J'--account=do006' -S spack_spec='sombrero@2021-08-16%oneapi@2021.1'
[ReFrame Setup]
  version:           4.2.0
  command:           '/cosma/home/do006/dc-gior1/repo/excalibur-tests/excal/bin/reframe -c benchmarks/examples/sombrero/ -r --performance-report --system cosma8 -J--account=do006 -S spack_spec=sombrero@2021-08-16%oneapi@2021.1'
  launched by:       dc-gior1@login8b.pri.cosma7.alces.network
  working directory: '/cosma/home/do006/dc-gior1/repo/excalibur-tests'
  settings files:    '<builtin>', '/cosma/home/do006/dc-gior1/repo/excalibur-tests/benchmarks/reframe_config.py'
  check search path: '/cosma/home/do006/dc-gior1/repo/excalibur-tests/benchmarks/examples/sombrero'
  stage directory:   '/cosma/home/do006/dc-gior1/repo/excalibur-tests/stage'
  output directory:  '/cosma/home/do006/dc-gior1/repo/excalibur-tests/output'
  log files:         '/tmp/rfm-lmnetmg7.log'

[==========] Running 1 check(s)
[==========] Started on Mon May 22 16:14:02 2023

[----------] start processing checks
[ RUN      ] SombreroBenchmark /cc391b86 @cosma8:compute-node+default
[       OK ] (1/1) SombreroBenchmark /cc391b86 @cosma8:compute-node+default
P: flops: 3.71 Gflops/seconds (r:3.8, l:-0.2, u:None)
[----------] all spawned checks have finished

[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped, 0 aborted)
[==========] Finished on Mon May 22 16:15:14 2023

=================================================================================================================================================================================================================
PERFORMANCE REPORT
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[SombreroBenchmark /cc391b86 @cosma8:compute-node:default]
  num_tasks_per_node: 1
  num_cpus_per_task: 1
  num_tasks: 1
  performance:
    - flops: 3.71 Gflops/seconds (r: 3.8 Gflops/seconds l: -20.0% u: +inf%)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

$ reframe -c benchmarks/examples/sombrero/ -r --performance-report --system cosma8 -J'--account=do006' -S spack_spec='sombrero@2021-08-16%oneapi@2021.3.0'
[ReFrame Setup]
  version:           4.2.0
  command:           '/cosma/home/do006/dc-gior1/repo/excalibur-tests/excal/bin/reframe -c benchmarks/examples/sombrero/ -r --performance-report --system cosma8 -J--account=do006 -S spack_spec=sombrero@2021-08-16%oneapi@2021.3.0'
  launched by:       dc-gior1@login8b.pri.cosma7.alces.network
  working directory: '/cosma/home/do006/dc-gior1/repo/excalibur-tests'
  settings files:    '<builtin>', '/cosma/home/do006/dc-gior1/repo/excalibur-tests/benchmarks/reframe_config.py'
  check search path: '/cosma/home/do006/dc-gior1/repo/excalibur-tests/benchmarks/examples/sombrero'
  stage directory:   '/cosma/home/do006/dc-gior1/repo/excalibur-tests/stage'
  output directory:  '/cosma/home/do006/dc-gior1/repo/excalibur-tests/output'
  log files:         '/tmp/rfm-16svw9kq.log'

[==========] Running 1 check(s)
[==========] Started on Mon May 22 16:16:44 2023

[----------] start processing checks
[ RUN      ] SombreroBenchmark /cc391b86 @cosma8:compute-node+default
[     FAIL ] (1/1) SombreroBenchmark /cc391b86 @cosma8:compute-node+default
P: flops: 2.43 Gflops/seconds (r:3.8, l:-0.2, u:None)
==> test failed during 'performance': test staged in '/cosma/home/do006/dc-gior1/repo/excalibur-tests/stage/cosma8/compute-node/default/SombreroBenchmark'
[----------] all spawned checks have finished

[  FAILED  ] Ran 1/1 test case(s) from 1 check(s) (1 failure(s), 0 skipped, 0 aborted)
[==========] Finished on Mon May 22 16:17:29 2023
=================================================================================================================================================================================================================
SUMMARY OF FAILURES
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FAILURE INFO for SombreroBenchmark (run: 1/1)
  * Description:
  * System partition: cosma8:compute-node
  * Environment: default
  * Stage directory: /cosma/home/do006/dc-gior1/repo/excalibur-tests/stage/cosma8/compute-node/default/SombreroBenchmark
  * Node list:
  * Job type: batch job (id=6230541)
  * Dependencies (conceptual): []
  * Dependencies (actual): []
  * Maintainers: []
  * Failing phase: performance
  * Rerun with '-n /cc391b86 -p default --system cosma8:compute-node -r'
  * Reason: performance error: failed to meet reference: flops=2.43, expected 3.8 (l=3.04, u=inf)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

==================================================================================================================================================================================================================
PERFORMANCE REPORT
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[SombreroBenchmark /cc391b86 @cosma8:compute-node:default]
  num_tasks_per_node: 1
  num_tasks: 1
  num_cpus_per_task: 1
  performance:
    - flops: 2.43 Gflops/seconds (r: 3.8 Gflops/seconds l: -20.0% u: +inf%)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```