### PR TITLE
Speed up pip install by excluding unnecessary files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,6 @@ include benchmarks/reframe_config.py
 recursive-include benchmarks/apps *
 recursive-include benchmarks/examples *
 recursive-include benchmarks/modules *
-recursive-include benchmarks/spack *
+recursive-include benchmarks/spack *.yaml
+recursive-include benchmarks/spack/repo *
+prune __pycache__


### PR DESCRIPTION
Closes #154 

Pip install can become slow if we include everything from `benchmarks/spack` because spack writes stuff in there. In this PR we only include the `.yaml` files from the spack environments. From the custom package repo I'm including everything except the `__pycache__` directories. Maybe this could also be restricted to `.py` and `.yaml` files, but I'm not expecting anything else to end up there.