### PR TITLE
Name Fix for Isambard Phase 3 Instinct System

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -297,7 +297,7 @@ site_configuration = {
                     ],
                 },
                 {
-                    'name': 'instict',
+                    'name': 'instinct',
                     'descr': 'AMD Instinct GPU nodes with 4x AMD Instinct "MI100" GPU',
                     'scheduler': 'pbs',
                     'launcher': 'mpirun',


### PR DESCRIPTION
After encountering the following error message, I checked the `reframe-config.py` file and found a missing letter in the name
```
$ reframe -c benchmarks/apps/babelstream -r --tag hip --system=isambard-phase3:instinct -S build_locally=false -S spack_spec='babelstream@develop%gcc@9.2.0 +rocm amdgpu_target=gfx908'
ERROR: failed to load configuration: could not find a configuration entry for the requested system/partition combination: 'isambard-phase3:instinct'
Log file(s) saved in '/tmp/rfm-fn32usc9.log'
```
