### PR TITLE
Install pandas and pytest as dependencies of excalibur-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
         with:
           python-version: '3.10.6'
           cache: 'pip'
-      - name: Install Reframe
+          
+      - name: Install Excalibur-tests
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install . --target ${{runner.workspace}}/pip
-          echo "PATH=${{runner.workspace}}/pip/bin:${PATH}" >> "${GITHUB_ENV}"
+          pip install .[test]
       - name: Install Spack
         shell: bash
         working-directory: ${{runner.workspace}}
@@ -55,21 +55,16 @@ jobs:
       - name: ReFrame version number
         shell: bash
         run: reframe -V
-      - name: Install Pytest + Pandas
-        shell: bash
-        run: |
-          pip install pytest
-          pip install pandas
       - name: Install OpenMPI, CMake and extra Python packages
         shell: bash
         run: sudo apt-get install openmpi-bin libopenmpi-dev cmake
       - name: Run sample benchmark
         shell: bash
         run: |
-          export RFM_CONFIG_FILES="${{runner.workspace}}/pip/benchmarks/reframe_config.py"
-          reframe -v -c ${{runner.workspace}}/pip/benchmarks/examples/sombrero --run --performance-report --system github-actions:default -S'spack_spec=${{ matrix.spack_spec }}'
+          export RFM_CONFIG_FILES=$Python_ROOT_DIR/lib/python3.10/site-packages/benchmarks/reframe_config.py
+          reframe -v -c $Python_ROOT_DIR/lib/python3.10/site-packages/benchmarks/examples/sombrero --run --performance-report --system github-actions:default -S'spack_spec=${{ matrix.spack_spec }}'
       - name: Post-processing tests
         shell: bash
         run: |
-          export RFM_CONFIG_FILES="${{runner.workspace}}/pip/benchmarks/reframe_config.py"
+          export RFM_CONFIG_FILES=$Python_ROOT_DIR/lib/python3.10/site-packages/benchmarks/reframe_config.py
           pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,20 @@ dependencies = [
     "pandas >= 2.0.1",
 ]
 
+[project.optional-dependencies]
+test = [
+  'pytest >= 6.0',
+]
+
 [tool.setuptools_scm]
 
 [tool.setuptools]
 include-package-data = true
 
 [tool.setuptools.packages.find]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = [
+    "post-processing",
+]


### PR DESCRIPTION
Following up from my [review comments](https://github.com/ukri-excalibur/excalibur-tests/pull/121#discussion_r1205538810) I thought we should be able to `pip install` everything we need in one go.

- It looks like setting the `--target` flag to `pip` was breaking `pytest` on the GHA runners, the error is in [this failed action](https://github.com/tkoskela/excalibur-tests/actions/runs/5153671619/jobs/9281190331)
- I first thought of using a virtual environment but again [struggled with setting the path correctly](https://github.com/tkoskela/excalibur-tests/actions/runs/5155188057/jobs/9284547982)
- In the end, it works by just installing into the default python path which now seems short enough for spack. 