### PR TITLE
Fix setting of `num_slots` resources for SGE scheduler

### DIFF
--- a/benchmarks/modules/utils.py
+++ b/benchmarks/modules/utils.py
@@ -279,7 +279,7 @@ class SpackTest(rfm.RegressionTest):
     @run_before('compile')
     def set_sge_num_slots(self):
         # Set the total number of CPUs to be requested for the SGE scheduler.
-        self.extra_resources['mpi']: {'num_slots': self.num_tasks * self.num_cpus_per_task}
+        self.extra_resources['mpi'] = {'num_slots': self.num_tasks * self.num_cpus_per_task}
 
     @run_after('setup')
     def setup_build_job_num_cpus(self):


### PR DESCRIPTION
Error introduced in #139, but I could test it only today.  Glorified comments aka type hinting strikes again.