### PR TITLE
[hpcg] Allow building with any MPI implementation

### DIFF
--- a/benchmarks/spack/repo/packages/hpcg_excalibur/package.py
+++ b/benchmarks/spack/repo/packages/hpcg_excalibur/package.py
@@ -29,7 +29,7 @@ class HpcgExcalibur(MakefilePackage):
         sha256="1a1928189828f43b8391258d051887762865ed63e54aaabbe4059c14fa788529"
     )
     
-    depends_on("openmpi")
+    depends_on("mpi")
 
     maintainers = ["dcaseGH"]
 


### PR DESCRIPTION
Ref: https://github.com/ukri-excalibur/excalibur-tests/pull/157#discussion_r1200754814.  I had a quick look at the code of hpcg and I couldn't see _**anything**_ specific to OpenMPI.  I ran this branch on Myriad with Intel MPI + Intel compiler:
```
$ reframe -c benchmarks/apps/hpcg/ -r --performance-report --system myriad:cpu --name HPCG_Stencil -S spack_spec='hpcg_excalibur@hpcg_stencil%intel ^intel-mpi'
[...]
PERFORMANCE REPORT
---------------------------------------------------------------------------
[HPCG_Stencil /21b95432 @myriad:cpu:default]
  num_tasks_per_node: 36
  num_tasks: 36
  num_cpus_per_task: 1
  performance:
    - flops: 37.9305 Gflops/seconds (r: 1 Gflops/seconds l: -inf% u: +inf%)
---------------------------------------------------------------------------
```