### PR TITLE
[csd3-skylake] Fix settings of Intel compilers for building Babelstream

### DIFF
--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -407,19 +407,7 @@ spack:
           LD_LIBRARY_PATH: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
       extra_rpaths:
       - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
-  - compiler:
-      spec: oneapi@2022.2.1
-      paths:
-        cc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/icx
-        cxx: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/icpx
-        f77: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
-        fc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
-      flags: {}
-      operating_system: centos7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
+      - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/lib
   - compiler:
       spec: dpcpp@2021.3.0
       paths:

--- a/benchmarks/spack/csd3-skylake/compute-node/spack.yaml
+++ b/benchmarks/spack/csd3-skylake/compute-node/spack.yaml
@@ -114,19 +114,6 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: intel@19.0.4.243
-      paths:
-        cc: /usr/local/Cluster-Apps/intel/2019.4/compilers_and_libraries_2019.4.243/linux/bin/intel64/icc
-        cxx: /usr/local/Cluster-Apps/intel/2019.4/compilers_and_libraries_2019.4.243/linux/bin/intel64/icpc
-        f77: /usr/local/Cluster-Apps/intel/2019.4/compilers_and_libraries_2019.4.243/linux/bin/intel64/ifort
-        fc: /usr/local/Cluster-Apps/intel/2019.4/compilers_and_libraries_2019.4.243/linux/bin/intel64/ifort
-      flags: {}
-      operating_system: scientific7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
       spec: intel@19.1.2.254
       paths:
         cc: /usr/local/Cluster-Apps/intel/2020.2/compilers_and_libraries_2020.2.254/linux/bin/intel64/icc
@@ -136,9 +123,11 @@ spack:
       flags: {}
       operating_system: scientific7
       target: x86_64
-      modules: []
+      modules:
+      - intel/compilers/2020.2
       environment: {}
-      extra_rpaths: []
+      extra_rpaths:
+      - /usr/local/Cluster-Apps/intel/2020.2/compilers_and_libraries_2020.2.254/linux/lib
   - compiler:
       spec: intel@19.1.3.304
       paths:
@@ -149,9 +138,12 @@ spack:
       flags: {}
       operating_system: scientific7
       target: x86_64
-      modules: []
+      modules:
+      - gcc/9
+      - intel/compilers/2020.4
       environment: {}
-      extra_rpaths: []
+      extra_rpaths:
+      - /usr/local/Cluster-Apps/intel/2020.4/compilers_and_libraries_2020.4.304/linux/lib
   packages:
     all:
       target: [skylake_avx512]


### PR DESCRIPTION
Remove unusable `intel@19.0.4.243`, compilation using this compiler fails with
```
  >> 95     icpc: error #10408: The Intel LLVM Based compiler cannot be found i
            n the expected location.  Please check your installation or documen
            tation for more information.
  >> 96     /usr/local/Cluster-Apps/intel/2019.4/compilers_and_libraries_2019.4
            .243/linux/bin/intel64/icx: No such file or directory
```

I successfully ran the babelstream benchmark with
```
reframe -c benchmarks/apps/babelstream -r --system csd3-skylake:compute-node --job-option='--account=...' -S spack_spec='babelstream%intel@XXX +omp' --tag omp
```
for all versions of the Intel compilers on CSD3 (after removing one that was unusable).

Fix #173