### PR TITLE
Add oneAPI Compiler to Isambard-MACS

### DIFF
--- a/benchmarks/spack/isambard-macs/compilers.yaml
+++ b/benchmarks/spack/isambard-macs/compilers.yaml
@@ -72,3 +72,42 @@ compilers:
     - pgi/64
     environment: {}
     extra_rpaths: []
+- compiler:
+    spec: intel@=2023.1.0
+    paths:
+      cc: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/intel64/icc
+      cxx: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/intel64/icpc
+      f77: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/intel64/ifort
+      fc: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2023.1.0
+    paths:
+      cc: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/icx
+      cxx: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/icpx
+      f77: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/ifx
+      fc: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2023.1.0
+    paths:
+      cc: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/icx
+      cxx: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/dpcpp
+      f77: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/ifx
+      fc: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/benchmarks/spack/isambard-macs/compilers.yaml
+++ b/benchmarks/spack/isambard-macs/compilers.yaml
@@ -96,7 +96,9 @@ compilers:
     operating_system: rhel8
     target: x86_64
     modules: []
-    environment: {}
+    environment: 
+      append_path:
+        LD_LIBRARY_PATH: /projects/bristol/modules/intel-oneapi-2023.1.0/compiler/2023.1.0/linux/compiler/lib/intel64/
     extra_rpaths: []
 - compiler:
     spec: dpcpp@=2023.1.0


### PR DESCRIPTION
cc: @giordano , @dcaseGH 

I have tested and it builds fine but when trying to run the job it gives the libimf.so not found error: 
```
omp-stream: error while loading shared libraries: libimf.so: cannot open shared object file: No such file or directory
```

Can you also check it ? 
```
reframe -c benchmarks/apps/babelstream -r --tag omp --system=isambard-macs:cascadelake --setvar=num_cpus_per_task=8 -S build_locally=false -S spack_spec='babelstream%oneapi@2023.1.0 +omp intel_target=a'
```

Strangely, https://github.com/ukri-excalibur/excalibur-tests/pull/181#issuecomment-1626315961 this method I used didn't raise any libimf.so errors that I tested on MACS