### PR TITLE
Remove lower bound to avoid issues during tutorial

### DIFF
--- a/benchmarks/examples/sombrero/sombrero.py
+++ b/benchmarks/examples/sombrero/sombrero.py
@@ -64,7 +64,7 @@ class SombreroBenchmark(SpackTest):
         # matched by the other entries of the dictionary and can be used to
         # provide a default reference value.
         'archer2': {
-            'flops': (1.2, -0.2, None, 'Gflops/seconds'),
+            'flops': (1.2, None, None, 'Gflops/seconds'),
         },
         'cosma8': {
             'flops': (3.8, -0.2, None, 'Gflops/seconds'),


### PR DESCRIPTION
This gets rid of failures in the sombrero example because of too low performance numbers on Archer2.