### PR TITLE
Keep `spack.lock` file after a successful benchmark finishes

### DIFF
--- a/benchmarks/apps/wrf/wrf.py
+++ b/benchmarks/apps/wrf/wrf.py
@@ -67,7 +67,7 @@ class WRFBaseBenchmark(SpackTest):
 
     executable = 'wrf.exe'
     executable_opts = []
-    keep_files = ['rsl.error.0000']
+    keep_files.append('rsl.error.0000')
 
     num_cpus_per_task = 2
     num_tasks = required

--- a/benchmarks/modules/utils.py
+++ b/benchmarks/modules/utils.py
@@ -268,6 +268,10 @@ class SpackTest(rfm.RegressionTest):
             f'spack -e {self.build_system.environment} config add "config:install_tree:root:{env_dir}/opt"',
         ]
 
+        # Keep the `spack.lock` file in the output directory so that the Spack
+        # environment can be faithfully reproduced later.
+        self.keep_files.append(os.path.realpath(os.path.join(self.build_system.environment, 'spack.lock')))
+
     @run_before('compile')
     def setup_build_system(self):
         # The `self.spack_spec` attribute is the user-facing and loggable


### PR DESCRIPTION
I tested locally with the Sombrero benchmark and it seems to be doing the job, the file `spack.lock` is preserved in the output directory together with the other log files.

Note: in the benchmarks we should always append to `self.keep_files`, instead of forcibly overwriting its value. 

Fix #210.