### PR TITLE
UOL's DiRAC apps minor update...

### DIFF
--- a/benchmarks/apps/ramses/ramses.py
+++ b/benchmarks/apps/ramses/ramses.py
@@ -33,7 +33,7 @@ class RamsesMPI(SpackTest):
 
     reference = {
             '*': {
-                'Total elapsed time': (500, None, None, 'seconds'),
+                'elapsed_time': (500, None, None, 'seconds'),
                 },
             }
 
@@ -56,9 +56,9 @@ class RamsesMPI(SpackTest):
     def validate_successful_run(self):
         return sn.assert_found(r'Run completed', self.stdout)
 
-    @performance_function('seconds', perf_key='Total elapsed time')
+    @performance_function('seconds', perf_key='elapsed_time')
     def extract_elapsed_time(self):
-        return sn.extractsingle(r'Total elapsed time:\s+(\S+)\s', self.stdout, 1, float)
+        return sn.extractsingle(r'elapsed_time:\s+(\S+)\s', self.stdout, 1, float)
 
 
 @rfm.simple_test

--- a/benchmarks/apps/sphng/sphng.py
+++ b/benchmarks/apps/sphng/sphng.py
@@ -61,7 +61,7 @@ class SphngBase_evolution(SphngBase):
 
     reference = {
         'dial:slurm-local': {
-            'elapsed-time': (10, None, None, 'minutes'),
+            'elapsed_time': (10, None, None, 'minutes'),
             },
         }
 
@@ -69,7 +69,7 @@ class SphngBase_evolution(SphngBase):
     def validate_successful_run(self):
         return sn.assert_found(r'ended on', self.stdout)
 
-    @performance_function('minutes', perf_key='elapsed-time')
+    @performance_function('minutes', perf_key='elapsed_time')
     def extract_elapsed_time(self):
         return sn.extractsingle(r'cpu time used for this run :\s+(\S+)\s', self.stdout, 1, float)
 

--- a/benchmarks/apps/sphng/sphng.py
+++ b/benchmarks/apps/sphng/sphng.py
@@ -61,7 +61,7 @@ class SphngBase_evolution(SphngBase):
 
     reference = {
         'dial:slurm-local': {
-            'Total elapsed time': (10, None, None, 'minutes'),
+            'elapsed-time': (10, None, None, 'minutes'),
             },
         }
 
@@ -69,7 +69,7 @@ class SphngBase_evolution(SphngBase):
     def validate_successful_run(self):
         return sn.assert_found(r'ended on', self.stdout)
 
-    @performance_function('minutes', perf_key='Total elapsed time')
+    @performance_function('minutes', perf_key='elapsed-time')
     def extract_elapsed_time(self):
         return sn.extractsingle(r'cpu time used for this run :\s+(\S+)\s', self.stdout, 1, float)
 

--- a/benchmarks/apps/trove-pdsyev/pdsyev.py
+++ b/benchmarks/apps/trove-pdsyev/pdsyev.py
@@ -23,7 +23,7 @@ class PdsyevBase(SpackTest):
 
     reference = {
             '*': {
-                'diagonlization': (200, None, None, 'seconds'),
+                'elapsed_time': (200, None, None, 'seconds'),
                 },
             }
 
@@ -68,7 +68,7 @@ class PdsyevBase(SpackTest):
     def validate_successful_run(self):
         return sn.assert_found(r'Diagonalization finished successfully', self.stdout)
 
-    @performance_function('seconds', perf_key='diagonlization')
+    @performance_function('seconds', perf_key='elapsed_time')
     def extract_elapsed_time(self):
         return sn.extractsingle(r'Time to diagonalize matrix is \s+(\S+)\s', self.stdout, 1, float)
 

--- a/benchmarks/apps/trove/trove.py
+++ b/benchmarks/apps/trove/trove.py
@@ -19,7 +19,7 @@ class TroveBase(SpackTest):
 
     reference = {
             'dial:slurm-local': {
-                'Total elapsed time': (500, None, None, 'seconds'),
+                'elapsed_time': (500, None, None, 'seconds'),
                 },
             }
 
@@ -42,7 +42,7 @@ class TroveBase(SpackTest):
     def validate_successful_run(self):
         return sn.assert_found(r'End of TROVE', self.stdout)
 
-    @performance_function('seconds', perf_key='Total elapsed time')
+    @performance_function('seconds', perf_key='elapsed_time')
     def extract_elapsed_time(self):
         return sn.extractsingle(r'TROVE\s{30}\s+(\S+)\s+(\S+)', self.stdout, 2, float)
 


### PR DESCRIPTION
`+ python excalibur-tests/post-processing/post_processing.py perflogs ppp_config.yaml -d -v
Found log files:
- perflogs/dial3/compute-node/Sphng_Strong_Scaling_evolution.log
- perflogs/dial3/compute-node/Osu_allreduce.log
- perflogs/dial3/compute-node/Osu_bibw.log
- perflogs/dial3/compute-node/TROVE_14N.log
- perflogs/dial3/compute-node/TROVE_12N.log
- perflogs/dial3/compute-node/Osu_bw.log
- perflogs/dial3/compute-node/Sphng_Weak_Scaling_evolution.log
- perflogs/dial3/compute-node/Osu_latency.log
- perflogs/dial3/compute-node/RamsesMPI_weak.log
- perflogs/dial3/compute-node/Osu_allgather.log
- perflogs/dial3/compute-node/TROVE_16N.log
- perflogs/dial3/compute-node/RamsesMPI_strong.log
- perflogs/dial3/compute-node/PdsyevSingle.log
- perflogs/dial3/compute-node/Osu_alltoall.log
- perflogs/dial3/compute-node/Sphng_Single_Node_evolution.log

Discarding Sphng_Strong_Scaling_evolution.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding TROVE_14N.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding TROVE_12N.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding Sphng_Weak_Scaling_evolution.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding RamsesMPI_weak.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding TROVE_16N.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding RamsesMPI_strong.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

Discarding Sphng_Single_Node_evolution.log: KeyError: Perflog missing one or more required fields ['job_completion_time', '\\w+_value$', '\\w+_unit$', 'display_name']

KeyError: ('Could not find columns', ['Total elapsed time_value'])
Post-processing stopped`