### PR TITLE
UOL's DiRAC apps minor update2...

### DIFF
--- a/benchmarks/apps/ramses/ramses.py
+++ b/benchmarks/apps/ramses/ramses.py
@@ -58,7 +58,7 @@ class RamsesMPI(SpackTest):
 
     @performance_function('seconds', perf_key='elapsed_time')
     def extract_elapsed_time(self):
-        return sn.extractsingle(r'elapsed_time:\s+(\S+)\s', self.stdout, 1, float)
+        return sn.extractsingle(r'Total elapsed time:\s+(\S+)\s', self.stdout, 1, float)
 
 
 @rfm.simple_test


### PR DESCRIPTION
The [previous merge](https://github.com/ukri-excalibur/excalibur-tests/pull/234) introduced a typo error that prevents running the Ramses correctly which has been fixed now.