### PR TITLE
[sombrero] Handle systems where number of cores doesn't divide lattice volume

### DIFF
--- a/benchmarks/apps/sombrero/README.md
+++ b/benchmarks/apps/sombrero/README.md
@@ -24,6 +24,8 @@ using the `--tag=<TAG>` command line option of `reframe`:
    (as described [here](https://github.com/sa2c/sombrero/wiki/Dirac-ITT-2020-Benchmarks)).
 - `ITT-64n`: A run on 64 nodes, using all the cores in each node
    (as described [here](https://github.com/sa2c/sombrero/wiki/Dirac-ITT-2020-Benchmarks)).
+   The number of nodes used can be changed by setting the variable `num_nodes`,
+   for example `reframe ... -S num_nodes=48`.
 - `scaling`: A large benchmarking campaign, where of the benchmarks is launched 
              on a range of number of processes
              (depending on the setup of the machine)

--- a/benchmarks/apps/sombrero/sombrero.py
+++ b/benchmarks/apps/sombrero/sombrero.py
@@ -130,6 +130,7 @@ class SombreroITTsn(SombreroBenchmarkBase):
 class SombreroITT64n(SombreroBenchmarkBase):
     valid_systems = ['-gpu']
     tags = {"ITT-64n"}
+    num_nodes = variable(int, value=64, loggable=False)
 
     @run_after('init')
     def set_up_from_parameters(self):
@@ -139,6 +140,6 @@ class SombreroITT64n(SombreroBenchmarkBase):
     def setup_num_tasks(self):
         self.num_tasks_per_node = max_num_tasks(
             self.current_partition.processor.num_cores,
-            LATTICE_VOLUME_MEDIUM // 64,
+            LATTICE_VOLUME_MEDIUM // self.num_nodes,
         )
-        self.num_tasks = self.num_tasks_per_node * 64
+        self.num_tasks = self.num_tasks_per_node * self.num_nodes

--- a/benchmarks/apps/sombrero/sombrero.py
+++ b/benchmarks/apps/sombrero/sombrero.py
@@ -11,7 +11,8 @@ from benchmarks.modules.reframe_extras import scaling_config
 from benchmarks.modules.utils import SpackTest
 
 # Fixed lattice volume in ITT benchmarks
-LATTICE_VOLUME = 32 * 24 * 24 * 24
+LATTICE_VOLUME_SMALL = 32 * 24 ** 3
+LATTICE_VOLUME_MEDIUM = 48 ** 3 * 64
 
 
 # Helper function to find maximum number of tasks we can use for benchmarks
@@ -122,9 +123,8 @@ class SombreroITTsn(SombreroBenchmarkBase):
     def setup_num_tasks(self):
         self.num_tasks = max_num_tasks(
             self.current_partition.processor.num_cores,
-            LATTICE_VOLUME,
+            LATTICE_VOLUME_SMALL,
         )
-
 
 @rfm.simple_test
 class SombreroITT64n(SombreroBenchmarkBase):
@@ -137,7 +137,8 @@ class SombreroITT64n(SombreroBenchmarkBase):
 
     @run_after('setup')
     def setup_num_tasks(self):
-        self.num_tasks = max_num_tasks(
-            self.current_partition.processor.num_cores * 64,
-            LATTICE_VOLUME,
+        self.num_tasks_per_node = max_num_tasks(
+            self.current_partition.processor.num_cores,
+            LATTICE_VOLUME_MEDIUM // 64,
         )
+        self.num_tasks = self.num_tasks_per_node * 64

--- a/benchmarks/apps/sombrero/sombrero.py
+++ b/benchmarks/apps/sombrero/sombrero.py
@@ -5,11 +5,23 @@
 
 import reframe as rfm
 import reframe.utility.sanity as sn
-import reframe.utility.udeps as udeps
 
 from benchmarks.apps.sombrero import case_filter
 from benchmarks.modules.reframe_extras import scaling_config
 from benchmarks.modules.utils import SpackTest
+
+# Fixed lattice volume in ITT benchmarks
+LATTICE_VOLUME = 32 * 24 * 24 * 24
+
+
+# Helper function to find maximum number of tasks we can use for benchmarks
+# which assume the number of cores divide a fixed lattice volume.
+def max_num_tasks(n, volume):
+    num_tasks = 1
+    for i in range(2, n + 1):
+        if volume % i == 0:
+            num_tasks = i
+    return num_tasks
 
 
 @rfm.simple_test
@@ -108,7 +120,10 @@ class SombreroITTsn(SombreroBenchmarkBase):
 
     @run_after('setup')
     def setup_num_tasks(self):
-        self.num_tasks = self.current_partition.processor.num_cores
+        self.num_tasks = max_num_tasks(
+            self.current_partition.processor.num_cores,
+            LATTICE_VOLUME,
+        )
 
 
 @rfm.simple_test
@@ -122,4 +137,7 @@ class SombreroITT64n(SombreroBenchmarkBase):
 
     @run_after('setup')
     def setup_num_tasks(self):
-        self.num_tasks = self.current_partition.processor.num_cores * 64
+        self.num_tasks = max_num_tasks(
+            self.current_partition.processor.num_cores * 64,
+            LATTICE_VOLUME,
+        )


### PR DESCRIPTION
Should fix https://github.com/ukri-excalibur/excalibur-tests/issues/237#issuecomment-1827595717.  I followed the suggestion in https://github.com/ukri-excalibur/excalibur-tests/issues/237#issuecomment-1828323882.  Probably this isn't the most efficient algorithm out there, but this takes a bunch of microseconds on my laptop, so hopefully it won't be a major performance bottleneck:
```
In [7]: %%timeit
   ...: max_num_tasks(112, LATTICE_VOLUME)
   ...: 
   ...: 
3.75 µs ± 24.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

CC: @mirenradia.