### PR TITLE
[docs] Rewrite URLs in Markdown files for docs previews

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,13 +67,21 @@ jobs:
           # (reframe tests, input files, etc...) should be ignored by the docs.
           find benchmarks/apps -type f \! \( -name 'README.md' \) -print -delete
 
+      - name: Rewrite URLs in Markdown files for previews
+        # Run only if this is a PR for which we're going to deploy the preview.
+        if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork }}
+        run: |
+          BASE_URL="https://ukri-excalibur.github.io/excalibur-tests"
+          echo "BASE_URL=${BASE_URL}" >> "${GITHUB_ENV}"
+          PREVIEW_SUBDIR="preview/PR${{ github.event.number }}"
+          echo "PREVIEW_SUBDIR=${PREVIEW_SUBDIR}" >> "${GITHUB_ENV}"
+          find . -name '*.md' -print -exec sed -i "s|${BASE_URL}|${BASE_URL}/${PREVIEW_SUBDIR}|g" '{}' \;
+
       - name: Build docs
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-              PREVIEW_SUBDIR="preview/PR${{ github.event.number }}"
-              echo "PREVIEW_SUBDIR=${PREVIEW_SUBDIR}" >> "${GITHUB_ENV}"
               export MKDOCS_SITE_DIR="site/${PREVIEW_SUBDIR}"
-              export MKDOCS_SITE_URL="https://ukri-excalibur.github.io/excalibur-tests/${PREVIEW_SUBDIR}"
+              export MKDOCS_SITE_URL="${BASE_URL}/${PREVIEW_SUBDIR}"
           fi
           mkdocs build
 
@@ -120,8 +128,9 @@ jobs:
 
           sha = "${{ github.event.pull_request.head.sha }}"
           state = "success"
+          base_url = os.getenv("BASE_URL")
           preview_subdir = os.getenv("PREVIEW_SUBDIR")
-          target_url = f"https://ukri-excalibur.github.io/excalibur-tests/{preview_subdir}/"
+          target_url = f"{base_url}/{preview_subdir}/"
           description = "Documentation deployed"
           context = "${{ github.workflow }} / Preview"
           repo.create_status(sha, state, target_url, description, context)


### PR DESCRIPTION
In #294 I noticed that the links in the main page (coming from the top-level `README.md`) of the docs preview were pointing to the "production" website, not the preview one, because of course if the Markdown files have any links they'd point to the production version.  With this step we should be able to automatically rewrite the links, so as to keep them within the preview docs.

***Edit***: to confirm this works, see how the links in the [Documentation](https://ukri-excalibur.github.io/excalibur-tests/preview/PR295/#documentation) section now point to pages within the preview.