### PR TITLE
[CI] Do not rewrite links in symlinked files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,8 @@ jobs:
           echo "BASE_URL=${BASE_URL}" >> "${GITHUB_ENV}"
           PREVIEW_SUBDIR="preview/PR${{ github.event.number }}"
           echo "PREVIEW_SUBDIR=${PREVIEW_SUBDIR}" >> "${GITHUB_ENV}"
-          find . -name '*.md' -print -exec sed -i "s|${BASE_URL}|${BASE_URL}/${PREVIEW_SUBDIR}|g" '{}' \;
+          # Edit only files, and not symlinks, to avoid double editing the same files.
+          find . -type f -name '*.md' -print -exec sed -i "s|${BASE_URL}|${BASE_URL}/${PREVIEW_SUBDIR}|g" '{}' \;
 
       - name: Build docs
         run: |


### PR DESCRIPTION
If we rewrite the hyperlinks in symlinked files we risk to accidentally append duplicate `${PREVIEW_SUBDIR}`, depending on the order with which `find` operates on the files.

Should fix #304.