### PR TITLE
[CI] Allow empty git commit when deploying docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -112,7 +112,7 @@ jobs:
           fi
           cp -fr ../site/* .
           git add .
-          git commit -m "${COMMIT_MESSAGE}"
+          git commit --allow-empty -m "${COMMIT_MESSAGE}"
           git push origin gh-pages
 
       - name: Create custom status for pull requests


### PR DESCRIPTION
I believe with mkdocs
[v1.6.0](https://github.com/mkdocs/mkdocs/releases/tag/1.6.0) we may have to allow empty commits, because the compressed sitemap shouldn't change anymore on every rebuild.