### PR TITLE
[Spack] Remove old `dpcpp` compiler from all environments

### DIFF
--- a/benchmarks/spack/cosma7/compilers.yaml
+++ b/benchmarks/spack/cosma7/compilers.yaml
@@ -389,58 +389,6 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: dpcpp@2021.1
-    paths:
-      cc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icx
-      cxx: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/dpcpp
-      f77: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
-      fc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: dpcpp@2021.1-beta08
-    paths:
-      cc: null
-      cxx: /cosma/local/intel/oneAPI_2021.1.8/compiler/latest/linux/bin/dpcpp
-      f77: null
-      fc: null
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: dpcpp@2021.3.0
-    paths:
-      cc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/icx
-      cxx: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/dpcpp
-      f77: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
-      fc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: dpcpp@2022.0.0
-    paths:
-      cc: /cosma/local/intel/oneAPI_2022.1.2/compiler/2022.0.2/linux/bin/icx
-      cxx: /cosma/local/intel/oneAPI_2022.1.2/compiler/2022.0.2/linux/bin/dpcpp
-      f77: /cosma/local/intel/oneAPI_2022.1.2/compiler/2022.0.2/linux/bin/ifx
-      fc: /cosma/local/intel/oneAPI_2022.1.2/compiler/2022.0.2/linux/bin/ifx
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: oneapi@2021.1
     paths:
       cc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/icx

--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -408,32 +408,6 @@ spack:
       extra_rpaths:
       - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
       - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/lib
-  - compiler:
-      spec: dpcpp@2021.3.0
-      paths:
-        cc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/icx
-        cxx: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/dpcpp
-        f77: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
-        fc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
-      flags: {}
-      operating_system: centos7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
-      spec: dpcpp@2022.2.1
-      paths:
-        cc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/icx
-        cxx: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/dpcpp
-        f77: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
-        fc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/ifx
-      flags: {}
-      operating_system: centos7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
   packages:
     autoconf:
       externals:

--- a/benchmarks/spack/csd3-centos7/cascadelake/spack.yaml
+++ b/benchmarks/spack/csd3-centos7/cascadelake/spack.yaml
@@ -158,19 +158,6 @@ spack:
       extra_rpaths:
       - /usr/local/Cluster-Apps/intel/2020.4/compilers_and_libraries_2020.4.304/linux/lib
   - compiler:
-      spec: dpcpp@=2022.0.0
-      paths:
-        cc: /usr/local/software/intel/oneapi/2022.1/compiler/2022.0.2/linux/bin/icx
-        cxx: /usr/local/software/intel/oneapi/2022.1/compiler/2022.0.2/linux/bin/dpcpp
-        f77: /usr/local/software/intel/oneapi/2022.1/compiler/2022.0.2/linux/bin/ifx
-        fc: /usr/local/software/intel/oneapi/2022.1/compiler/2022.0.2/linux/bin/ifx
-      flags: {}
-      operating_system: centos7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
       spec: intel@=2021.5.0
       paths:
         cc: /usr/local/software/intel/oneapi/2022.1/compiler/2022.0.2/linux/bin/intel64/icc

--- a/benchmarks/spack/csd3-rocky8/compilers.yaml
+++ b/benchmarks/spack/csd3-rocky8/compilers.yaml
@@ -39,19 +39,6 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: dpcpp@=2022.1.0
-    paths:
-      cc: /usr/local/software/spack/spack-views/rocky8-icelake-20220710/intel-oneapi-compilers-2022.1.0/gcc-11.3.0/b6zld2mz7cid27yloxznoidymd7vywwz/compiler/2022.1.0/linux/bin/icx
-      cxx: /usr/local/software/spack/spack-views/rocky8-icelake-20220710/intel-oneapi-compilers-2022.1.0/gcc-11.3.0/b6zld2mz7cid27yloxznoidymd7vywwz/compiler/2022.1.0/linux/bin/dpcpp
-      f77: /usr/local/software/spack/spack-views/rocky8-icelake-20220710/intel-oneapi-compilers-2022.1.0/gcc-11.3.0/b6zld2mz7cid27yloxznoidymd7vywwz/compiler/2022.1.0/linux/bin/ifx
-      fc: /usr/local/software/spack/spack-views/rocky8-icelake-20220710/intel-oneapi-compilers-2022.1.0/gcc-11.3.0/b6zld2mz7cid27yloxznoidymd7vywwz/compiler/2022.1.0/linux/bin/ifx
-    flags: {}
-    operating_system: rocky8
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: intel@=2021.6.0
     paths:
       cc: /usr/local/software/spack/spack-views/rocky8-icelake-20220710/intel-oneapi-compilers-2022.1.0/gcc-11.3.0/b6zld2mz7cid27yloxznoidymd7vywwz/compiler/2022.1.0/linux/bin/intel64/icc

--- a/benchmarks/spack/dial3/compute-node/spack.yaml
+++ b/benchmarks/spack/dial3/compute-node/spack.yaml
@@ -49,19 +49,6 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: dpcpp@2021.2.0
-      paths:
-        cc: /cm/shared/spack/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-oneapi-compilers-2021.2.0-3q6eevirvd6g4brzipx22aef3imfqouj/compiler/2021.2.0/linux/bin/icx
-        cxx: /cm/shared/spack/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-oneapi-compilers-2021.2.0-3q6eevirvd6g4brzipx22aef3imfqouj/compiler/2021.2.0/linux/bin/dpcpp
-        f77: /cm/shared/spack/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-oneapi-compilers-2021.2.0-3q6eevirvd6g4brzipx22aef3imfqouj/compiler/2021.2.0/linux/bin/ifx
-        fc: /cm/shared/spack/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-oneapi-compilers-2021.2.0-3q6eevirvd6g4brzipx22aef3imfqouj/compiler/2021.2.0/linux/bin/ifx
-      flags: {}
-      operating_system: rocky8
-      target: x86_64
-      modules: [ intel-oneapi-compilers/2021.2.0/3q6eev ]
-      environment: {}
-      extra_rpaths: []
-  - compiler:
       spec: intel@2021.2.0
       paths:
         cc: /cm/shared/spack/opt/spack/linux-centos8-zen/gcc-8.3.1/intel-oneapi-compilers-2021.2.0-3q6eevirvd6g4brzipx22aef3imfqouj/compiler/2021.2.0/linux/bin/intel64/icc

--- a/benchmarks/spack/isambard-phase3/compilers.yaml
+++ b/benchmarks/spack/isambard-phase3/compilers.yaml
@@ -67,19 +67,6 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: dpcpp@2021.4.0
-    paths:
-      cc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/icx
-      cxx: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/dpcpp
-      f77: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/ifx
-      fc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/ifx
-    flags: {}
-    operating_system: rhel8
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: intel@2021.4.0
     paths:
       cc: /lustre/software/x86/tools/oneapi-2021.4.0/compiler/2021.4.0/linux/bin/intel64/icc


### PR DESCRIPTION
Fix #319.