### PR TITLE
Add ReFrame config for CSD3 Ponte Vecchio (Dawn) partition

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -125,7 +125,7 @@ site_configuration = {
                     'name': 'pvc',
                     'descr': 'Ponte Vecchio (Dawn) compute nodes',
                     'scheduler': 'slurm',
-                    'launcher': 'mpirun',
+                    'launcher': 'srun',
                     'env_vars': [
                         ['I_MPI_PMI_LIBRARY', '/usr/local/software/slurm/current-rhel8/lib/libpmi2.so'],
                         ['I_MPI_OFI_PROVIDER', 'mlx'],

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -120,6 +120,7 @@ site_configuration = {
                         'num_sockets': 2,
                         'num_cpus_per_socket': 56,
                     },
+                },
                 {
                     'name': 'pvc',
                     'descr': 'Ponte Vecchio (Dawn) compute nodes',
@@ -148,6 +149,7 @@ site_configuration = {
                             'name': 'gpu',
                             'options': ['--gres=gpu:{num_gpus_per_node}'],
                         },
+                    ],
 
                 },
             ]

--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -120,6 +120,35 @@ site_configuration = {
                         'num_sockets': 2,
                         'num_cpus_per_socket': 56,
                     },
+                {
+                    'name': 'pvc',
+                    'descr': 'Ponte Vecchio (Dawn) compute nodes',
+                    'scheduler': 'slurm',
+                    'launcher': 'mpirun',
+                    'env_vars': [
+                        ['I_MPI_PMI_LIBRARY', '/usr/local/software/slurm/current-rhel8/lib/libpmi2.so'],
+                        ['I_MPI_OFI_PROVIDER', 'mlx'],
+                        ['UCX_NET_DEVICES', 'mlx5_0:1'],
+                    ],
+                    'access': ['--partition=pvc', '--exclusive'],
+                    'sched_options': {
+                        'job_submit_timeout': 120,
+                    },
+                    'environs': ['default'],
+                    'max_jobs': 64,
+                    'features': ['gpu'],
+                    'processor': {
+                        'num_cpus': 96,
+                        'num_cpus_per_core': 1,
+                        'num_sockets': 2,
+                        'num_cpus_per_socket': 48,
+                    },
+                    'resources': [
+                        {
+                            'name': 'gpu',
+                            'options': ['--gres=gpu:{num_gpus_per_node}'],
+                        },
+
                 },
             ]
         },  # end CSD3 Rocky 8


### PR DESCRIPTION
I've ran several benchmarks (Stream, Sombrero, Babelstream) successfully with this. Does it look ok?

I haven't included a spack env because Kacper recommended chaining to the Dawn spack instance. There is a script `/usr/local/dawn/software/spack/spack-tools/bin/spack-dawn-upstream.sh` which does it. I think this is in general a better idea than maintaining our own spack envs. Ideas welcome how to do it in a sustainable way.