### PR TITLE
Some changes to `spack_root_to_path`

### DIFF
--- a/benchmarks/reframe_config.py
+++ b/benchmarks/reframe_config.py
@@ -18,16 +18,23 @@ def spack_root_to_path():
     spack_root = os.getenv('SPACK_ROOT')
     path = os.getenv('PATH')
     if spack_root is None:
+        # Somehow we don't know what's the Spack root, then return PATH as is,
+        # but if also PATH is not set (what a dramatic case) then return an
+        # empty string.
+        return "" if path is None else path
+
+    spack_bindir = os.path.join(spack_root, 'bin')
+    if path is None:
+        # Somehow PATH isn't set, only return `spack_bindir`
+        return spack_bindir
+
+    if spack_bindir in path.split(os.path.pathsep):
+        # `spack_bindir` is already in PATH, return the environment
+        # variable as is.
         return path
-    else:
-        spack_bindir = os.path.join(spack_root, 'bin')
-        if path is None:
-            return dir
-        else:
-            if spack_bindir in path.split(os.path.pathsep):
-                return path
-            else:
-                return spack_bindir * os.path.pathsep * path
+
+    # `spack_bindir` isn't in PATH already, prepend to it.
+    return spack_bindir + os.path.pathsep + path
 
 
 site_configuration = {


### PR DESCRIPTION
* Add comments to improve clarity of all the conditions considered
* There were unnecessary `else` branches
* Cater for the dramatic case where both `SPACK_ROOT` and `PATH` are not set
* Fix the case where `PATH` isn't set but `SPACK_ROOT` is (we were returning the function `dir` before, fun)
* Fix the case where `spack_bindir` isn't in `PATH` (we were using `*` for non-commutative concatenation of strings, it turns out in Python one should use `+` instead for this operation)