### PR TITLE
Fix syntax warning in `setup_spack_environment`

### DIFF
--- a/benchmarks/modules/utils.py
+++ b/benchmarks/modules/utils.py
@@ -265,7 +265,7 @@ class SpackTest(rfm.RegressionTest):
             # Copy Spack environment (only specific YAML files) to the stage
             # directory.
             f'mkdir -p {dest}',
-            f'(cd {cp_dir}; find . \( -name "spack.yaml" -o -name "compilers.yaml" -o -name "packages.yaml" \) -print0 | xargs -0 tar cf - | tar -C {dest} -xvf -)',
+            f'(cd {cp_dir}; find . \\( -name "spack.yaml" -o -name "compilers.yaml" -o -name "packages.yaml" \\) -print0 | xargs -0 tar cf - | tar -C {dest} -xvf -)',
             f'spack -e {self.build_system.environment} config add "config:install_tree:root:{env_dir}/opt"',
         ]
         cmd_spack_spec_dict =   'from spack import environment;\


### PR DESCRIPTION
Add double escape to silence warnings in python 3.12