### PR TITLE
[stream] Set number of CPUs/task based on available CPUs

### DIFF
--- a/benchmarks/examples/stream/stream.py
+++ b/benchmarks/examples/stream/stream.py
@@ -4,6 +4,7 @@
 # Import modules from reframe and excalibur-tests
 import reframe as rfm
 import reframe.utility.sanity as sn
+from reframe.core.backends import getlauncher
 from benchmarks.modules.utils import SpackTest
 
 @rfm.simple_test
@@ -45,6 +46,19 @@ class StreamBenchmark(SpackTest):
             min(1, (self.current_partition.processor.num_cpus_per_core or 1)))
         self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
         self.env_vars['OMP_PLACES'] = 'cores'
+
+
+    # Unlike many of the other benchmarks we support, this one doesn't use
+    # MPI. Since in principle an MPI launcher may not be available on the
+    # compute node out-of-the-box unless explicitly requested, to avoid issues
+    # in case `mpirun`/`mpiexec` aren't readily available we always force the
+    # local launcher:
+    # <https://reframe-hpc.readthedocs.io/en/v4.6.3/tutorial.html#replacing-the-launch-command>.
+    # This function is not needed for all other benchmarks which do need MPI.
+    @run_before('run')
+    def replace_launcher(self):
+        self.job.launcher = getlauncher('local')()
+
 
     ## Build configuration
     ## Comment/uncomment the appropriate one

--- a/benchmarks/examples/stream/stream.py
+++ b/benchmarks/examples/stream/stream.py
@@ -22,11 +22,6 @@ class StreamBenchmark(SpackTest):
     num_tasks = 1
 
     time_limit = '5m'
-    num_cpus_per_task = 128
-    env_vars = {
-        'OMP_NUM_THREADS': f'{num_cpus_per_task}',
-        'OMP_PLACES': 'cores'
-    }
     use_multithreading = False
 
     ## Reference performance values for Archer2
@@ -38,6 +33,18 @@ class StreamBenchmark(SpackTest):
             'Triad': (200000, -0.25, 0.25, 'MB/s')
         }
     }
+
+
+    # Automatically set default value of `num_cpus_per_task` based on number of
+    # CPUs on a node.
+    @run_after('setup')
+    def setup_num_tasks(self):
+        self.set_var_default(
+            'num_cpus_per_task',
+            (self.current_partition.processor.num_cpus or 1) //
+            min(1, (self.current_partition.processor.num_cpus_per_core or 1)))
+        self.env_vars['OMP_NUM_THREADS'] = f'{self.num_cpus_per_task}'
+        self.env_vars['OMP_PLACES'] = 'cores'
 
     ## Build configuration
     ## Comment/uncomment the appropriate one


### PR DESCRIPTION
With this PR I was able to run the `stream` example benchmark on my new laptop, the caveat being that I need to manually set `-S num_cpus_per_task=22` on the command line to be able to run with the right number of cores (I tried to follow the [example in the documentation](https://reframe-hpc.readthedocs.io/en/v4.6.3/tutorial.html#accessing-cpu-topology-information) to automatically discover the topology of the system, but the only result was to completely skip the test due to the call to [`skip_if_no_procinfo`](https://reframe-hpc.readthedocs.io/en/v4.6.3/regression_test_api.html#reframe.core.pipeline.RegressionTest.skip_if_no_procinfo))