### PR TITLE
[spack] Update environment for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-24.04
         spack_version:
           # In README.md we claim compatibility with v0.20.0
           - v0.20.0

--- a/benchmarks/spack/github-actions/default/spack.yaml
+++ b/benchmarks/spack/github-actions/default/spack.yaml
@@ -10,92 +10,66 @@ spack:
   - ../../common.yaml
   compilers:
   - compiler:
-      spec: clang@12.0.1
+      spec: clang@=16.0.6
       paths:
-        cc: /usr/bin/clang-12
-        cxx: /usr/bin/clang++-12
+        cc: /usr/bin/clang-16
+        cxx: /usr/bin/clang++-16
         f77: null
         fc: null
       flags: {}
-      operating_system: ubuntu22.04
+      operating_system: ubuntu24.04
       target: x86_64
       modules: []
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: clang@13.0.1
+      spec: clang@=17.0.6
       paths:
-        cc: /usr/bin/clang-13
-        cxx: /usr/bin/clang++-13
+        cc: /usr/bin/clang-17
+        cxx: /usr/bin/clang++-17
         f77: null
         fc: null
       flags: {}
-      operating_system: ubuntu22.04
+      operating_system: ubuntu24.04
       target: x86_64
       modules: []
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: clang@14.0.0
+      spec: clang@=18.1.3
       paths:
         cc: /usr/bin/clang
         cxx: /usr/bin/clang++
         f77: null
         fc: null
       flags: {}
-      operating_system: ubuntu22.04
+      operating_system: ubuntu24.04
       target: x86_64
       modules: []
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: gcc@9.5.0
-      paths:
-        cc: /usr/bin/gcc-9
-        cxx: /usr/bin/g++-9
-        f77: /usr/bin/gfortran-9
-        fc: /usr/bin/gfortran-9
-      flags: {}
-      operating_system: ubuntu22.04
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
-      spec: gcc@10.4.0
-      paths:
-        cc: /usr/bin/gcc-10
-        cxx: /usr/bin/g++-10
-        f77: /usr/bin/gfortran-10
-        fc: /usr/bin/gfortran-10
-      flags: {}
-      operating_system: ubuntu22.04
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
-      spec: gcc@11.3.0
+      spec: gcc@=13.3.0
       paths:
         cc: /usr/bin/gcc
         cxx: /usr/bin/g++
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
       flags: {}
-      operating_system: ubuntu22.04
+      operating_system: ubuntu24.04
       target: x86_64
       modules: []
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: gcc@12.1.0
+      spec: gcc@=14.2.0
       paths:
-        cc: /usr/bin/gcc-12
-        cxx: /usr/bin/g++-12
-        f77: null
-        fc: null
+        cc: /usr/bin/gcc-14
+        cxx: /usr/bin/g++-14
+        f77: /usr/bin/gfortran-14
+        fc: /usr/bin/gfortran-14
       flags: {}
-      operating_system: ubuntu22.04
+      operating_system: ubuntu24.04
       target: x86_64
       modules: []
       environment: {}
@@ -103,12 +77,12 @@ spack:
   packages:
     cmake:
       externals:
-      - spec: cmake@3.22.1
+      - spec: cmake@3.28.3
         prefix: /usr
-      - spec: cmake@3.25.0
+      - spec: cmake@3.31.5
         prefix: /usr/local
     openmpi:
       externals:
-      - spec: openmpi@4.1.2%gcc@11.3.0~cuda+cxx~cxx_exceptions+java~memchecker+pmi~static~wrapper-rpath
+      - spec: openmpi@4.1.6%gcc@=13.3.0~cuda+cxx~cxx_exceptions+java~memchecker+pmi~static~wrapper-rpath
           fabrics=ofi,psm,psm2,ucx schedulers=slurm
         prefix: /usr


### PR DESCRIPTION
I'm a bit torn about how to best fix #359.  I tried [automatically populating the Spack environment](https://github.com/ukri-excalibur/excalibur-tests/commit/4631503010a1389d8b21400335c4b2e9fa468b7c) in every job, which should hopefully always ensure consistency, but [that step can take over a minute](https://github.com/ukri-excalibur/excalibur-tests/actions/runs/13244795136/job/36968533449#step:9:1), depending on the mood of the machine. The solution proposed here (just manually update the environment) is less future-proof, but would avoid wasting time in every job.  I'm happy to change to the other solution if considered preferable.