### PR TITLE
[kathleen] Add `+generic-names` to `intel-oneapi-mpi`

### DIFF
--- a/benchmarks/spack/kathleen/compute-node/spack.yaml
+++ b/benchmarks/spack/kathleen/compute-node/spack.yaml
@@ -249,7 +249,7 @@ spack:
         prefix: /shared/ucl/apps/intel/2020
     intel-oneapi-mpi:
       externals:
-      - spec: intel-oneapi-mpi@2021.6.0
+      - spec: intel-oneapi-mpi@2021.6.0 +generic-names
         prefix: /shared/ucl/apps/intel/2022.2/
     libtool:
       externals:


### PR DESCRIPTION
Compiler wrappers use generic names, let Spack know it so that it can find them correctly.