### PR TITLE
Fix arepo to run on cosma.

### DIFF
--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -20,7 +20,7 @@ spack:
         cflags: null
         cxxflags: null
         fflags: null
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -33,7 +33,7 @@ spack:
         f77: /cosma/local/aocc/AOCC-1.3.0-Compiler/bin/flang
         fc: /cosma/local/aocc/AOCC-1.3.0-Compiler/bin/flang
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -46,7 +46,7 @@ spack:
         f77: /usr/bin/gfortran44
         fc: /usr/bin/gfortran44
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -59,7 +59,7 @@ spack:
         f77: /cosma/local/aocc/AOCC-1.3.0-Fortran-Prerequisites/gcc_4.8.2_install/bin/gfortran
         fc: /cosma/local/aocc/AOCC-1.3.0-Fortran-Prerequisites/gcc_4.8.2_install/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -72,7 +72,7 @@ spack:
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -88,7 +88,7 @@ spack:
         cflags: null
         cxxflags: null
         fflags: null
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -101,7 +101,7 @@ spack:
         f77: /cosma/local/aocc/2.0.0/bin/flang
         fc: /cosma/local/aocc/2.0.0/bin/flang
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -117,7 +117,7 @@ spack:
         cflags: null
         cxxflags: null
         fflags: null
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -133,7 +133,7 @@ spack:
         cflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
         cxxflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
         fflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -149,7 +149,7 @@ spack:
         cflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
         cxxflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
         fflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -165,7 +165,7 @@ spack:
         cflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
         cxxflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
         fflags: -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -178,7 +178,7 @@ spack:
         f77: /cosma/local/gcc/7.3.0/bin/gfortran
         fc: /cosma/local/gcc/7.3.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -191,7 +191,7 @@ spack:
         f77: /cosma/local/gcc/8.2.0/bin/gfortran
         fc: /cosma/local/gcc/8.2.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -204,7 +204,7 @@ spack:
         f77: /cosma/local/gcc/9.1.0/bin/gfortran
         fc: /cosma/local/gcc/9.1.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -217,7 +217,7 @@ spack:
         f77: /cosma/local/gcc/9.3.0/bin/gfortran
         fc: /cosma/local/gcc/9.3.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -230,7 +230,7 @@ spack:
         f77: /cosma/local/gcc/10.2.0/bin/gfortran
         fc: /cosma/local/gcc/10.2.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -243,7 +243,7 @@ spack:
         f77: /cosma/local/gcc/11.1.0/bin/gfortran
         fc: /cosma/local/gcc/11.1.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -256,7 +256,7 @@ spack:
         f77: /cosma/local/gcc/13.1.0/bin/gfortran
         fc: /cosma/local/gcc/13.1.0/bin/gfortran
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -269,7 +269,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2017-update1/compilers_and_libraries_2017.2.174/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2017-update1/compilers_and_libraries_2017.2.174/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -282,7 +282,7 @@ spack:
         f77: /cosma/local/Intel/Parallel_Studio_XE_2018/compilers_and_libraries_2018.2.199/linux/bin/intel64/ifort
         fc: /cosma/local/Intel/Parallel_Studio_XE_2018/compilers_and_libraries_2018.2.199/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -295,7 +295,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.3.199/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.3.199/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -308,7 +308,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -321,7 +321,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.2.187/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.2.187/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -334,7 +334,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.4.243/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2019/compilers_and_libraries_2019.4.243/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -347,7 +347,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.0.166/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.0.166/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -360,7 +360,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -373,7 +373,7 @@ spack:
         f77: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.2.254/linux/bin/intel64/ifort
         fc: /cosma/local/intel/Parallel_Studio_XE_2020/compilers_and_libraries_2020.2.254/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -386,7 +386,7 @@ spack:
         f77: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/intel64/ifort
         fc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -399,7 +399,7 @@ spack:
         f77: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/intel64/ifort
         fc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment: {}
@@ -412,7 +412,7 @@ spack:
         f77: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/intel64/ifort
         fc: /cosma/local/intel/oneAPI_2022.3.0/compiler/2022.2.1/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment:
@@ -428,7 +428,7 @@ spack:
         f77: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
         fc: /cosma/local/intel/oneAPI_2021.1.0/compiler/2021.1.1/linux/bin/ifx
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment:
@@ -444,7 +444,7 @@ spack:
         f77: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
         fc: /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/bin/ifx
       flags: {}
-      operating_system: centos7
+      operating_system: rocky9
       target: x86_64
       modules: []
       environment:
@@ -453,6 +453,22 @@ spack:
       extra_rpaths:
       - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/compiler/lib/intel64_lin
       - /cosma/local/intel/oneAPI_2021.3.0/compiler/2021.3.0/linux/lib
+  - compiler:
+      spec: oneapi@2024.2.0
+      paths:
+        cc: /cosma/local/intel/oneAPI_2024.2.0/compiler/2024.2/bin/icx
+        cxx: /cosma/local/intel/oneAPI_2024.2.0/compiler/2024.2/bin/icpx
+        f77: /cosma/local/intel/oneAPI_2024.2.0/compiler/2024.2/bin/ifx
+        fc: /cosma/local/intel/oneAPI_2024.2.0/compiler/2024.2/bin/ifx
+      flags: {}
+      operating_system: rocky9
+      target: x86_64
+      modules: []
+      environment:
+        prepend_path:
+          LD_LIBRARY_PATH: /cosma/local/intel/oneAPI_2024.2.0/compiler/2024.2/lib
+      extra_rpaths:
+      - /cosma/local/intel/oneAPI_2024.2.0/compiler/2024.2/lib
   packages:
     autoconf:
       externals:
@@ -546,6 +562,10 @@ spack:
       externals:
       - spec: groff@1.22.2
         prefix: /usr
+    hdf5:
+      externals:
+      - spec: hdf5@1.14.4
+        prefix: /cosma/local/hdf5/intel_2024.2.0/1.14.4
     krb5:
       externals:
       - spec: krb5@1.15.1
@@ -602,6 +622,8 @@ spack:
         prefix: /cosma/local/intel/oneAPI_2021.3.0
       - spec: intel-oneapi-mpi@2021.7.1+generic-names%oneapi@2022.2.1
         prefix: /cosma/local/intel/oneAPI_2022.3.0
+      - spec: intel-oneapi-mpi@2021.13+generic-names%oneapi@2024.2.0
+        prefix: /cosma/local/intel/oneAPI_2024.2.0/
     libfuse:
       externals:
       - spec: libfuse@2.9.2


### PR DESCRIPTION
Cherry-picked from #328 to close #339 
- Fix OS name in spack environment for cosma for new OS after upgrade
- Add some new packages and compilers to spack environment for cosma post-upgrade (they may or may not be needed for AREPO...)