### PR TITLE
 spack v1.0 support: %foo +bar -> +bar %foo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'benchmarks/reframe_config.py'
       - 'benchmarks/examples/**'
       - 'benchmarks/modules/**'
+      - 'benchmarks/spack/github-actions/**'
       - 'post-processing/**'
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - 'reframe_config.py'
       - 'benchmarks/examples/**'
       - 'benchmarks/modules/**'
+      - 'benchmarks/spack/github-actions/**'
       - 'post-processing/**'
   release:
 

--- a/benchmarks/spack/cosma8/compute-node/spack.yaml
+++ b/benchmarks/spack/cosma8/compute-node/spack.yaml
@@ -313,7 +313,7 @@ spack:
         prefix: /cosma/local/bash/5.2.21/
     boost:
       externals:
-      - spec: boost@1.67.0%gcc@10.2.0 arch=linux-centos7-zen2
+      - spec: boost@1.67.0 arch=linux-centos7-zen2 %gcc@10.2.0
         prefix: /cosma/local/boost/gnu_10.2.0/1_67_0/
     bzip2:
       externals:
@@ -467,14 +467,14 @@ spack:
         prefix: /usr
     mvapich2:
       externals:
-      - spec: mvapich2@2.3.6%gcc@11.1.0~cuda~debug~regcache~wrapperrpath fabrics=mrail
-          process_managers=hydra threads=multiple
+      - spec: mvapich2@2.3.6~cuda~debug~regcache~wrapperrpath fabrics=mrail
+          process_managers=hydra threads=multiple %gcc@11.1.0
         prefix: /cosma/local/mvapich2/gnu_11.1.0/2.3.6
-      - spec: mvapich2@2.3.6%gcc@10.2.0~cuda~debug~regcache~wrapperrpath fabrics=mrail
-          process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.6~cuda~debug~regcache~wrapperrpath fabrics=mrail
+          process_managers=slurm threads=multiple %gcc@10.2.0
         prefix: /cosma/local/mvapich2/gnu_10.2.0/2.3.6
-      - spec: mvapich2@2.3.6%gcc@9.3.0~cuda~debug~regcache~wrapperrpath fabrics=mrail
-          process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.6~cuda~debug~regcache~wrapperrpath fabrics=mrail
+          process_managers=slurm threads=multiple %gcc@9.3.0
         prefix: /cosma/local/mvapich2/gnu_9.3.0/2.3.6
     ncurses:
       externals:
@@ -486,47 +486,47 @@ spack:
         prefix: /usr
     openmpi:
       externals:
-      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%intel
-          schedulers=slurm
+      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %intel
         prefix: /cosma/local/openmpi/intel_2018/3.0.1
-      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
-          schedulers=slurm
+      - spec: openmpi@3.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@7.3.0
         prefix: /cosma/local/openmpi/gnu_7.3.0/3.0.1
-      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@10.2.0
-          schedulers=slurm
+      - spec: openmpi@3.0.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@10.2.0
         prefix: /cosma/local/openmpi/gnu_10.2.0/3.0.1
-      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@1.3.0
-          schedulers=slurm
+      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+          schedulers=slurm %aocc@1.3.0
         prefix: /cosma/local/openmpi/aocc_1.3.0/4.0.1
-      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc@2.0.0
-          schedulers=slurm
+      - spec: openmpi@4.0.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%aocc
+          schedulers=slurm %aocc@2.0.0
         prefix: /cosma/local/openmpi/aocc_2.0.0/4.0.1
-      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
-          schedulers=slurm
+      - spec: openmpi@4.0.3~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@9.3.0
         prefix: /cosma/local/openmpi/gnu_9.3.0/4.0.3
-      - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%aocc@2.2.0
-          fabrics=ucx schedulers=slurm
+      - spec: openmpi@4.0.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          fabrics=ucx schedulers=slurm %aocc@2.2.0
         prefix: /cosma/local/openmpi/aocc_2.2.0/4.0.5
-      - spec: openmpi@4.1.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath%gcc@7.3.0
-          fabrics=ucx schedulers=slurm
+      - spec: openmpi@4.1.1~cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+          fabrics=ucx schedulers=slurm %gcc@7.3.0
         prefix: /cosma/local/openmpi/gnu_7.3.0/20190429
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@9.3.0
-          fabrics=ucx schedulers=slurm
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          fabrics=ucx schedulers=slurm %gcc@9.3.0
         prefix: /cosma/local/openmpi/gnu_9.3.0/4.1.1
-      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@11.1.0
-          schedulers=slurm
+      - spec: openmpi@4.1.1~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@11.1.0
         prefix: /cosma/local/openmpi/gnu_11.1.0/4.1.1.no-ucx
-      - spec: openmpi@4.1.4~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@11.1.0
-          schedulers=slurm
+      - spec: openmpi@4.1.4~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@11.1.0
         prefix: /cosma/local/openmpi/gnu_13.1.0/4.1.4
-      - spec: openmpi@4.1.4~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@13.1.0
-          schedulers=slurm
+      - spec: openmpi@4.1.4~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@13.1.0
         prefix: /cosma/local/openmpi/gnu_13.1.0/4.1.4
-      - spec: openmpi@4.1.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@13.1.0
-          schedulers=slurm
+      - spec: openmpi@4.1.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@13.1.0
         prefix: /cosma/local/openmpi/gnu_13.1.0/4.1.5
-      - spec: openmpi@4.1.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath%gcc@14.1.0
-          schedulers=slurm
+      - spec: openmpi@4.1.5~cuda+cxx+cxx_exceptions~java+lustre~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
+          schedulers=slurm %gcc@14.1.0
         prefix: /cosma/local/openmpi/gnu_14.1.0/4.1.5
     openssh:
       externals:

--- a/benchmarks/spack/csd3-centos7/cascadelake/spack.yaml
+++ b/benchmarks/spack/csd3-centos7/cascadelake/spack.yaml
@@ -269,13 +269,13 @@ spack:
         prefix: /usr/local/Cluster-Apps/gsl/2.4
     hdf5:
       externals:
-      - spec: hdf5@1.10.3%gcc@4.8.5~mpi
+      - spec: hdf5@1.10.3~mpi %gcc@4.8.5
         prefix: /usr/local/software/hdf5/1.10.3
-      - spec: hdf5@1.10.5%gcc@9.3.0+mpi^openmpi
+      - spec: hdf5@1.10.5+mpi %gcc@9.3.0^openmpi
         prefix: /usr/local/Cluster-Apps/hdf5/openmpi/gcc/9.2/1.10.5
       - spec: hdf5@1.10.5 +mpi^intel-mpi
         prefix: /usr/local/Cluster-Apps/hdf5/mpi/intel/2019.3/1.10.5
-      - spec: hdf5@1.12.0%gcc@9.3.0+mpi^openmpi
+      - spec: hdf5@1.12.0+mpi %gcc@9.3.0^openmpi
         prefix: /usr/local/Cluster-Apps/hdf5/openmpi/gcc/9.3/1.12.0
     intel-mkl:
       externals:

--- a/benchmarks/spack/github-actions/default/spack.yaml
+++ b/benchmarks/spack/github-actions/default/spack.yaml
@@ -83,6 +83,6 @@ spack:
         prefix: /usr/local
     openmpi:
       externals:
-      - spec: openmpi@4.1.6%gcc@=13.3.0~cuda+cxx~cxx_exceptions+java~memchecker+pmi~static~wrapper-rpath
-          fabrics=ofi,psm,psm2,ucx schedulers=slurm
+      - spec: openmpi@4.1.6~cuda+cxx~cxx_exceptions+java~memchecker+pmi~static~wrapper-rpath
+          fabrics=ofi,psm,psm2,ucx schedulers=slurm %gcc@=13.3.0
         prefix: /usr

--- a/benchmarks/spack/tursa/gpu/spack.yaml
+++ b/benchmarks/spack/tursa/gpu/spack.yaml
@@ -61,13 +61,13 @@ spack:
         prefix: /usr
     openmpi:
       externals:
-      - spec: openmpi@4.1.1%gcc@9.3.0+cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
-          fabrics=ucx schedulers=slurm
+      - spec: openmpi@4.1.1+cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+          fabrics=ucx schedulers=slurm %gcc@9.3.0
         prefix: /mnt/lustre/tursafs1/apps/basestack/cuda-11.4/openmpi/4.1.1-cuda11.4
-      - spec: openmpi@4.1.1%gcc@8.4.1+cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
-          fabrics=ucx schedulers=slurm
+      - spec: openmpi@4.1.1+cuda~cxx~cxx_exceptions~java~memchecker+pmi~sqlite3~static~thread_multiple~wrapper-rpath
+          fabrics=ucx schedulers=slurm %gcc@8.4.1
         prefix: /mnt/lustre/tursafs1/apps/basestack/cuda-11.0.2/openmpi/4.1.1
-      - spec: openmpi@4.0.4%gcc@8.4.1+cuda~cxx~cxx_exceptions~java~memchecker~pmi~sqlite3~thread_multiple~wrapper-rpath
+      - spec: openmpi@4.0.4+cuda~cxx~cxx_exceptions~java~memchecker~pmi~sqlite3~thread_multiple~wrapper-rpath %gcc@8.4.1
         prefix: /mnt/lustre/tursafs1/apps/openmpi/4.0.4
     perl:
       externals:


### PR DESCRIPTION
 Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
 with variant foo enabled" instead of "pkg with variant foo enabled and compiler
 gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
 v1.0.
