### PR TITLE
Update post-processing outputs

### DIFF
--- a/post-processing/README.md
+++ b/post-processing/README.md
@@ -32,14 +32,22 @@ pip install -e .[post-processing]
 #### Command line
 
 ```sh
-python post_processing.py log_path config_path [-p plot_type]
+python post_processing.py log_path config_path [-p plot_type] [-s save] [-o output_path] [-d debug]
 ```
 
 - `log_path` - Path to a perflog file, or a directory containing perflog files.
 - `config_path` - Path to a configuration file containing plot details.
-- `plot_type` - (Optional.) Type of plot to be generated. (`Note: only a generic bar chart is currently implemented.`)
+- `plot_type` - (Optional.) Type of plot to be generated. By default, no plotting occurs.
+  - `generic` - Bar chart.
+  - `line` - Line chart. (**TODO**)
+- `save` - (Optional.) State in which to save perflog data to a csv file. By default, no data is saved.
+  - `original` - Save the original perflog data with no filters or transformations applied.
+  - `filtered` - Save the original filtered perflog data with no transformations applied.
+  - `transformed` - Save the processed perflog data with all filters and transformations applied (log and scaling).
+- `output_path` - (Optional.) Path to a directory for storing a generated plot and csv data. By default, outputs are saved in the current directory.
+- `debug` - (Optional.) Print additional debug information.
 
-Run `post_processing.py -h` for more information (including debugging and file output flags).
+Run `post_processing.py -h` for a summary of this information.
 
 #### Streamlit
 

--- a/post-processing/plot_handler.py
+++ b/post-processing/plot_handler.py
@@ -12,7 +12,8 @@ from bokeh.transform import factor_cmap
 from titlecase import titlecase
 
 
-def plot_generic(title, df: pd.DataFrame, x_axis, y_axis, series_filters, debug=False):
+def plot_generic(title, df: pd.DataFrame, x_axis, y_axis, series_filters,
+                 output_path=Path(__file__).parent, debug=False):
     """
         Create a bar chart for the supplied data using bokeh.
 
@@ -22,6 +23,8 @@ def plot_generic(title, df: pd.DataFrame, x_axis, y_axis, series_filters, debug=
             x_axis: dict, x-axis column and units.
             y_axis: dict, y-axis column and units.
             series_filters: list, x-axis groups used to filter graph data.
+            output_path: Path, path to a directory for storing the generated plot.
+            debug: bool, flag to print additional information to console.
     """
 
     # get column names and labels for axes
@@ -59,7 +62,7 @@ def plot_generic(title, df: pd.DataFrame, x_axis, y_axis, series_filters, debug=
 
     # create html file to store plot in
     output_file(filename=os.path.join(
-        Path(__file__).parent, "{0}.html".format(title.replace(" ", "_"))), title=title)
+        output_path, "{0}.html".format(title.replace(" ", "_"))), title=title)
 
     # create plot
     plot = figure(x_range=grouped_df, y_range=(min_y, max_y), title=title,

--- a/post-processing/plot_handler.py
+++ b/post-processing/plot_handler.py
@@ -23,7 +23,7 @@ def plot_generic(title, df: pd.DataFrame, x_axis, y_axis, series_filters,
             x_axis: dict, x-axis column and units.
             y_axis: dict, y-axis column and units.
             series_filters: list, x-axis groups used to filter graph data.
-            output_path: Path, path to a directory for storing the generated plot.
+            output_path: Path, path to a directory for storing the generated plot and csv data. Default is current directory.
             debug: bool, flag to print additional information to console.
     """
 

--- a/post-processing/plot_handler.py
+++ b/post-processing/plot_handler.py
@@ -23,7 +23,8 @@ def plot_generic(title, df: pd.DataFrame, x_axis, y_axis, series_filters,
             x_axis: dict, x-axis column and units.
             y_axis: dict, y-axis column and units.
             series_filters: list, x-axis groups used to filter graph data.
-            output_path: Path, path to a directory for storing the generated plot and csv data. Default is current directory.
+            output_path: Path, path to a directory for storing the generated plot and csv data.
+                Default is current directory.
             debug: bool, flag to print additional information to console.
     """
 

--- a/post-processing/post_processing.py
+++ b/post-processing/post_processing.py
@@ -66,10 +66,23 @@ class PostProcessing:
         if self.debug:
             print("Selected dataframe:")
             print(self.df[self.mask][config.plot_columns + config.extra_columns])
+
         if self.save:
-            # set index=False to exclude the dataframe index from the csv
-            self.df[self.mask][config.plot_columns + config.extra_columns].to_csv(
-                path_or_buf=os.path.join(Path(__file__).parent, 'output.csv'), index=True)
+            os.makedirs(self.output_path, exist_ok=True)
+            csv_path = os.path.join(self.output_path, "output.csv")
+            # save original dataframe with no filters or transformations applied
+            if self.save == "original":
+                self.original_df.to_csv(path_or_buf=csv_path, index=True)
+            # save original filtered dataframe with no transformations applied
+            elif self.save == "filtered":
+                self.original_df[self.mask][config.plot_columns + config.extra_columns].to_csv(
+                    path_or_buf=csv_path, index=True)
+            # save processed dataframe
+            elif self.save == "transformed":
+                # set index=False to exclude the dataframe index from the csv
+                self.df[self.mask][config.plot_columns + config.extra_columns].to_csv(
+                    path_or_buf=csv_path, index=True)
+            print("Saved {0} dataframe to {1}".format(self.save, self.output_path))
 
         # call a plotting script
         if self.plotting:

--- a/post-processing/post_processing.py
+++ b/post-processing/post_processing.py
@@ -20,9 +20,10 @@ class PostProcessing:
             Args:
                 log_path: Path, path to performance log file or directory.
                 plot_type: str, type of plot to be generated and stored in an html file.
+                    Options: ['generic', 'line' (TODO)]
                 save: str, state of dataframe to save to csv file.
+                    Options: ['original', 'filtered', 'transformed']
                 output_path: Path, path to a directory for storing outputs. Default is current directory.
-
                 debug: bool, flag to print additional information to console.
         """
 

--- a/post-processing/post_processing.py
+++ b/post-processing/post_processing.py
@@ -21,7 +21,8 @@ class PostProcessing:
                 log_path: Path, path to performance log file or directory.
                 plot_type: str, type of plot to be generated and stored in an html file.
                 save: str, state of dataframe to save to csv file.
-                output_path: Path, path to a directory for storing outputs.
+                output_path: Path, path to a directory for storing outputs. Default is current directory.
+
                 debug: bool, flag to print additional information to console.
         """
 

--- a/post-processing/post_processing.py
+++ b/post-processing/post_processing.py
@@ -85,16 +85,13 @@ class PostProcessing:
             print("Saved {0} dataframe to {1}".format(self.save, self.output_path))
 
         # call a plotting script
-        if self.plotting:
-            self.plot = plot_generic(
-                config.title, self.df[self.mask][config.plot_columns],
-                config.x_axis, config.y_axis, config.series_filters, self.debug)
-
-        # FIXME (#issue #255): maybe save this bit to a file as well for easier viewing
-        if self.debug & self.verbose:
-            print("")
-            print("Full dataframe:")
-            print(self.df.to_json(orient="columns", indent=2))
+        if self.plot_type:
+            os.makedirs(self.output_path, exist_ok=True)
+            if self.plot_type == "generic":
+                self.plot = plot_generic(
+                    config.title, self.df[self.mask][config.plot_columns],
+                    config.x_axis, config.y_axis, config.series_filters, self.output_path, self.debug)
+            print("Saved {0} dataframe to {1}".format(self.plot_type, self.output_path))
 
         return self.df[self.mask][config.plot_columns]
 

--- a/post-processing/post_processing.py
+++ b/post-processing/post_processing.py
@@ -428,12 +428,13 @@ def read_args():
 
     # optional arguments
     parser.add_argument("-p", "--plot_type", type=str,
-                        help="type of plot to be generated")
+                        help="type of plot to be generated (default is no plot); \
+                            options: ['generic', 'line' (TODO)]")
     parser.add_argument("-s", "--save", type=str,
-                        help="one of 'original', 'filtered', or 'transformed' states in which \
-                            to save perflog data to a csv file")
+                        help="state in which to save perflog data to a csv file (default is no data saved); \
+                            options: ['original', 'filtered', 'transformed']")
     parser.add_argument("-o", "--output_path", type=Path, default=Path(__file__).parent,
-                        help="path to a directory for storing outputs")
+                        help="path to a directory for storing outputs (default is current directory)")
     parser.add_argument("-d", "--debug", action="store_true",
                         help="debug flag for printing additional information")
 

--- a/post-processing/test_post_processing.py
+++ b/post-processing/test_post_processing.py
@@ -559,7 +559,7 @@ def test_high_level_script(run_sombrero):
     assert len(df) == 1
 
     # get filtered dataframe with extra columns for csv
-    df = PostProcessing(sombrero_log_path, save=True).run_post_processing(
+    df = PostProcessing(sombrero_log_path, save="filtered").run_post_processing(
         ConfigHandler(
             {"title": "Title",
              "x_axis": {"value": "tasks",
@@ -589,7 +589,7 @@ def test_high_level_script(run_sombrero):
     assert len(df_saved) == 1
 
     # get filtered dataframe with duplicated extra columns for csv
-    df = PostProcessing(sombrero_log_path, save=True).run_post_processing(
+    df = PostProcessing(sombrero_log_path, save="filtered").run_post_processing(
         ConfigHandler(
             {"title": "Title",
              "x_axis": {"value": "tasks",


### PR DESCRIPTION
Addresses #306 and #307.

- [x] Perflog dataframe can be saved in various states:
	- `original` - original df containing all perflog data
	- `filtered` - filtered original df containing only relevant rows and columns
	- `transformed` - fully filtered and transformed df (i.e. scaling applied etc.)
- [x] Custom output path for saved dataframes and plots.